### PR TITLE
27 event engine

### DIFF
--- a/DolCon/Enums/SceneType.cs
+++ b/DolCon/Enums/SceneType.cs
@@ -1,0 +1,9 @@
+﻿namespace DolCon.Enums;
+
+public enum SceneType
+{
+    None,
+    Dialogue,
+    Battle,
+    Shop
+}

--- a/DolCon/Enums/Screen.cs
+++ b/DolCon/Enums/Screen.cs
@@ -5,5 +5,6 @@ public enum Screen
     Home = 72,
     Navigation = 78,
     Inventory = 73,
-    Quests = 81
+    Quests = 81,
+    Scene = -1
 }

--- a/DolCon/Models/Event.cs
+++ b/DolCon/Models/Event.cs
@@ -1,6 +1,15 @@
-﻿namespace DolCon.Models;
+﻿using DolCon.Models.BaseTypes;
+
+namespace DolCon.Models;
 
 public class Event
 {
-    
+    public Event(Location? currentLocation, Cell currentCell)
+    {
+        Location = currentLocation;
+        Area = currentCell;
+    }
+
+    public Location? Location { get; set; }
+    public Cell Area { get; set; }
 }

--- a/DolCon/Models/Event.cs
+++ b/DolCon/Models/Event.cs
@@ -1,0 +1,6 @@
+﻿namespace DolCon.Models;
+
+public class Event
+{
+    
+}

--- a/DolCon/Models/Item.cs
+++ b/DolCon/Models/Item.cs
@@ -4,4 +4,5 @@ public class Item
 {
     public string description { get; set; }
     public List<Tag> tags { get; set; }
+    public int price { get; set; }
 }

--- a/DolCon/Models/Scene.cs
+++ b/DolCon/Models/Scene.cs
@@ -6,12 +6,22 @@ public class Scene
 {
     public MoveStatus MoveStatus { get; set; }
     public string Message { get; set; }
-    public bool IsCompleted { get; set; }
+    public bool IsCompleted { get; set; } = true;
     public SceneType Type { get; set; }
     public string? Title { get; set; }
     public string? Description { get; set; }
-    public Dictionary<int, string> Selections { get; set; }
+    public Dictionary<int, string> Selections { get; set; } = new();
     public Service? SelectedService { get; set; }
     public int Selection { get; set; }
     public Location? Location { get; set; }
+
+    public void Reset()
+    {
+        Title = null;
+        Description = null;
+        Selections = new Dictionary<int, string>();
+        SelectedService = null;
+        Selection = 0;
+        Location = null;
+    }
 }

--- a/DolCon/Models/Scene.cs
+++ b/DolCon/Models/Scene.cs
@@ -1,6 +1,9 @@
 ﻿namespace DolCon.Models;
 
+using Enums;
+
 public class Scene
 {
-    
+    public MoveStatus MoveStatus { get; set; }
+    public string Message { get; set; }
 }

--- a/DolCon/Models/Scene.cs
+++ b/DolCon/Models/Scene.cs
@@ -6,4 +6,7 @@ public class Scene
 {
     public MoveStatus MoveStatus { get; set; }
     public string Message { get; set; }
+    public bool IsCompleted { get; set; }
+    public SceneType Type { get; set; }
+    public Service? SelectedService { get; set; }
 }

--- a/DolCon/Models/Scene.cs
+++ b/DolCon/Models/Scene.cs
@@ -8,5 +8,10 @@ public class Scene
     public string Message { get; set; }
     public bool IsCompleted { get; set; }
     public SceneType Type { get; set; }
+    public string? Title { get; set; }
+    public string? Description { get; set; }
+    public Dictionary<int, string> Selections { get; set; }
     public Service? SelectedService { get; set; }
+    public int Selection { get; set; }
+    public Location? Location { get; set; }
 }

--- a/DolCon/Models/Scene.cs
+++ b/DolCon/Models/Scene.cs
@@ -1,0 +1,6 @@
+﻿namespace DolCon.Models;
+
+public class Scene
+{
+    
+}

--- a/DolCon/Program.cs
+++ b/DolCon/Program.cs
@@ -15,6 +15,7 @@ using var host = Host.CreateDefaultBuilder(args)
         services.AddSingleton<IImageService, ImageService>();
         services.AddSingleton<IMoveService, MoveService>();
         services.AddSingleton<IEventService, EventService>();
+        services.AddSingleton<IShopService, ShopService>();
         services.AddHostedService<HostedService>();
     })
     .Build();

--- a/DolCon/Program.cs
+++ b/DolCon/Program.cs
@@ -1,5 +1,4 @@
-﻿using DolCon;
-using DolCon.Services;
+﻿using DolCon.Services;
 using DolCon.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -15,6 +14,7 @@ using var host = Host.CreateDefaultBuilder(args)
         services.AddSingleton<IGameService, GameService>();
         services.AddSingleton<IImageService, ImageService>();
         services.AddSingleton<IMoveService, MoveService>();
+        services.AddSingleton<IEventService, EventService>();
         services.AddHostedService<HostedService>();
     })
     .Build();

--- a/DolCon/Services/EventService.cs
+++ b/DolCon/Services/EventService.cs
@@ -1,9 +1,16 @@
-﻿namespace DolCon.Services;
+﻿using DolCon.Models;
+
+namespace DolCon.Services;
 
 public interface IEventService
 {
+    Scene ProcessEvent(Event thisEvent);
 }
 
 public class EventService : IEventService
 {
+    public Scene ProcessEvent(Event thisEvent)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/DolCon/Services/EventService.cs
+++ b/DolCon/Services/EventService.cs
@@ -11,6 +11,13 @@ public interface IEventService
 
 public class EventService : IEventService
 {
+    private readonly IShopService _shopService;
+
+    public EventService(IShopService shopService)
+    {
+        _shopService = shopService;
+    }
+
     public Scene ProcessEvent(Event thisEvent)
     {
         var scene = new Scene();
@@ -50,10 +57,11 @@ public class EventService : IEventService
         return scene;
     }
 
-    private static Scene ProcessServices(Event thisEvent, Scene scene)
+    private Scene ProcessServices(Event thisEvent, Scene scene)
     {
-        scene.Message = "Feature not implemented for Services: " + string.Join(", ", thisEvent.Location.Type.Services);
-        scene.MoveStatus = MoveStatus.None;
+        scene.Type = SceneType.Shop;
+        scene.Location = thisEvent.Location;
+        scene = _shopService.ProcessShop(scene);
         return scene;
     }
 

--- a/DolCon/Services/EventService.cs
+++ b/DolCon/Services/EventService.cs
@@ -37,7 +37,7 @@ public class EventService : IEventService
                 }
                 else
                 {
-                    scene.Message = "You are not in a location or area.";
+                    scene.Message = "You do not have enough stamina to explore the area.";
                 }
 
                 return scene;

--- a/DolCon/Services/EventService.cs
+++ b/DolCon/Services/EventService.cs
@@ -1,4 +1,6 @@
-﻿using DolCon.Models;
+﻿using ChanceNET;
+using DolCon.Enums;
+using DolCon.Models;
 
 namespace DolCon.Services;
 
@@ -11,6 +13,103 @@ public class EventService : IEventService
 {
     public Scene ProcessEvent(Event thisEvent)
     {
-        throw new NotImplementedException();
+        var scene = new Scene();
+        if (thisEvent.Location is { Type.Size: LocationSize.unexplorable })
+        {
+            scene.Message = "You cannot explore this area.";
+            scene.MoveStatus = MoveStatus.Hold;
+            return scene;
+        }
+
+        if (thisEvent.Location is { ExploredPercent: < 1 } || (thisEvent.Location is null && thisEvent.Area is { ExploredPercent: < 1 }))
+        {
+            scene.MoveStatus = ProcessExploration();
+            if (scene.MoveStatus == MoveStatus.Success)
+            {
+                var totalCoin = 0;
+                foreach (var player in SaveGameService.Party.Players)
+                {
+                    var random = new Chance().New();
+                    var playerCoin = random.Dice(100) * 10;
+                    player.coin += playerCoin;
+                    totalCoin += playerCoin;
+                }
+
+                scene.Message = "You have explored the area. You have found " + totalCoin + " coin.";
+            }
+            else
+            {
+                scene.Message = "You are not in a location or area.";
+            }
+
+            return scene;
+        }
+
+        scene.Message = "You have already explored this area.";
+        scene.MoveStatus = MoveStatus.Hold;
+
+        return scene;
+    }
+
+    private static MoveStatus ProcessExploration()
+    {
+        var party = SaveGameService.Party;
+        const int defaultExploration = 100;
+        var currentLocation = SaveGameService.CurrentLocation;
+        int locationExplorationSize;
+        double explored;
+        var currentBurg = SaveGameService.CurrentBurg;
+        if (currentLocation is not null)
+        {
+            if (!party.TryMove(.005)) return MoveStatus.Failure;
+
+            locationExplorationSize = (int)currentLocation.Type.Size * 100;
+            explored = currentLocation.ExploredPercent * locationExplorationSize;
+
+            explored += defaultExploration;
+
+            currentLocation.ExploredPercent = explored / locationExplorationSize;
+
+            return MoveStatus.Success;
+        }
+
+        if (currentBurg is not null) return MoveStatus.None;
+
+        if (!party.TryMove(.05)) return MoveStatus.Failure;
+
+        var currentCell = SaveGameService.CurrentCell;
+
+        locationExplorationSize = currentCell.CellSize == CellSize.small ? 300 : 500;
+
+        explored = currentCell.ExploredPercent * locationExplorationSize;
+        explored += defaultExploration;
+        currentCell.ExploredPercent = explored / locationExplorationSize;
+
+        if (Math.Abs(currentCell.ExploredPercent - 1) < .01)
+        {
+            currentCell.ExploredPercent = 1;
+            currentCell.locations.ForEach(x => x.Discovered = true);
+            return MoveStatus.Success;
+        }
+
+        var chance = new Chance();
+        var dice = chance.Dice(20);
+        if (dice > 0)
+        {
+            var random1 = new Random();
+            var pick1 = random1.Next(0, currentCell.locations.Count(x => !x.Discovered));
+            var location1 = currentCell.locations.Where(x => !x.Discovered).Skip(pick1)
+                .Take(1).First();
+            location1.Discovered = true;
+        }
+
+        if (dice < 12) return MoveStatus.Success;
+
+        var random2 = new Random();
+        var pick2 = random2.Next(0, currentCell.locations.Count(x => !x.Discovered));
+        var location2 = currentCell.locations.Where(x => !x.Discovered).Skip(pick2)
+            .Take(1).First();
+        location2.Discovered = true;
+        return MoveStatus.Success;
     }
 }

--- a/DolCon/Services/EventService.cs
+++ b/DolCon/Services/EventService.cs
@@ -1,0 +1,9 @@
+﻿namespace DolCon.Services;
+
+public interface IEventService
+{
+}
+
+public class EventService : IEventService
+{
+}

--- a/DolCon/Services/ShopService.cs
+++ b/DolCon/Services/ShopService.cs
@@ -1,0 +1,88 @@
+﻿using DolCon.Enums;
+using DolCon.Models;
+
+namespace DolCon.Services;
+
+public interface IShopService
+{
+    Scene ProcessShop(Scene scene);
+}
+
+public class ShopService : IShopService
+{
+    public Scene ProcessShop(Scene scene)
+    {
+        if (scene.Type != SceneType.Shop)
+        {
+            return scene;
+        }
+
+        var selection = scene.Selection;
+        var service = scene.SelectedService;
+
+        if (scene.Selections.Count == 0)
+        {
+            scene.Title = $"[bold black on white]Welcome to {scene.Location?.Name}[/]";
+            scene.Description = "Select a service.";
+            scene.Selections = new Dictionary<int, string>();
+            var i = 1;
+            var typeServices = scene.Location?.Type.Services;
+            if (typeServices == null)
+            {
+                scene.Message = "Invalid location.";
+                return scene;
+            }
+            foreach (var s in typeServices)
+            {
+                scene.Selections.Add(i, s.ToString());
+                i++;
+            }
+        }
+        
+        if (selection == scene.Selections.Count + 1)
+        {
+            scene.IsCompleted = true;
+            return scene;
+        }
+        
+        if(selection <= 0 || !scene.Selections.ContainsKey(selection))
+        {
+            scene.Message = "Invalid selection.";
+            return scene;
+        }
+
+        if (service == null)
+        {
+            scene.SelectedService = Enum.Parse<Service>(scene.Selections[selection]);
+            scene.Title = $"[bold black on white]{scene.SelectedService}[/]";
+            scene.Description = "Select purchase.";
+            scene.Selections = new Dictionary<int, string>();
+            var i = 1;
+            // TODO: Add items to selection
+            scene.Selections.Add(i, "Leave|0");
+            scene.Selection = 0;
+            return scene;
+        }
+        
+        var item = scene.Selections[selection].Split('|');
+        
+        var price = int.Parse(item[1]);
+        var playerMoney = SaveGameService.Party.Players[0].coin;
+
+        if (playerMoney < price)
+        {
+            scene.Message = "[red]You don't have enough money.[/]";
+            return scene;
+        }
+
+        SaveGameService.Party.Players[0].coin -= price;
+        // TODO: Add item to inventory
+        // Calculate money break down
+        var copper = price % 10;
+        var silver = (price / 10) % 10;
+        var gold = (price / 100) % 10;
+        scene.Message = $"You bought {item[0]} for {gold} gold, {silver} silver, and {copper} copper.";
+
+        return scene;
+    }
+}

--- a/DolCon/Services/ShopService.cs
+++ b/DolCon/Services/ShopService.cs
@@ -22,35 +22,32 @@ public class ShopService : IShopService
 
         if (scene.Selections.Count == 0)
         {
+            scene.IsCompleted = false;
             scene.Title = $"[bold black on white]Welcome to {scene.Location?.Name}[/]";
             scene.Description = "Select a service.";
             scene.Selections = new Dictionary<int, string>();
             var i = 1;
             var typeServices = scene.Location?.Type.Services;
-            if (typeServices == null)
-            {
-                scene.Message = "Invalid location.";
-                return scene;
-            }
+
             foreach (var s in typeServices)
             {
                 scene.Selections.Add(i, s.ToString());
                 i++;
             }
+            
+            scene.Selections.Add(i, "Leave");
+            scene.Message = "Select an option from the menu.";
+            return scene;
         }
         
-        if (selection == scene.Selections.Count + 1)
+        if (selection == scene.Selections.Count)
         {
             scene.IsCompleted = true;
+            scene.Message = "You left the shop.";
+            scene.Reset();
             return scene;
         }
         
-        if(selection <= 0 || !scene.Selections.ContainsKey(selection))
-        {
-            scene.Message = "Invalid selection.";
-            return scene;
-        }
-
         if (service == null)
         {
             scene.SelectedService = Enum.Parse<Service>(scene.Selections[selection]);
@@ -61,6 +58,7 @@ public class ShopService : IShopService
             // TODO: Add items to selection
             scene.Selections.Add(i, "Leave|0");
             scene.Selection = 0;
+            scene.Message = "Select an option from the menu.";
             return scene;
         }
         

--- a/DolCon/Views/GameService.Navigation.cs
+++ b/DolCon/Views/GameService.Navigation.cs
@@ -1,6 +1,7 @@
 ﻿namespace DolCon.Views;
 
 using ChanceNET;
+using Models;
 using Enums;
 using Models.BaseTypes;
 using Services;
@@ -109,20 +110,26 @@ public partial class GameService
                 moveStatus = _moveService.MoveToBurg(localBurg.i.Value) ? MoveStatus.Success : MoveStatus.Failure;
                 break;
             case 'e' when SaveGameService.CurrentLocation != null || SaveGameService.CurrentCell.ExploredPercent < 1:
-                moveStatus = _moveService.ProcessExploration();
-                if (moveStatus == MoveStatus.Success)
-                {
-                    var totalCoin = 0;
-                    foreach (var player in SaveGameService.Party.Players)
-                    {
-                        var random = new Chance().New();
-                        var playerCoin = random.Dice(100) * 10;
-                        player.coin += playerCoin;
-                        totalCoin += playerCoin;
-                    }
+                var thisEvent = new Event(SaveGameService.CurrentLocation, SaveGameService.CurrentCell);
+                
+                var scene = _eventService.ProcessEvent(thisEvent);
 
-                    message = "You have explored the area. You have found " + totalCoin + " coin.";
-                }
+                // moveStatus = _moveService.ProcessExploration();
+                moveStatus = scene.MoveStatus;
+                message = scene.Message;
+                // if (moveStatus == MoveStatus.Success)
+                // {
+                //     var totalCoin = 0;
+                //     foreach (var player in SaveGameService.Party.Players)
+                //     {
+                //         var random = new Chance().New();
+                //         var playerCoin = random.Dice(100) * 10;
+                //         player.coin += playerCoin;
+                //         totalCoin += playerCoin;
+                //     }
+                //
+                //     message = "You have explored the area. You have found " + totalCoin + " coin.";
+                // }
 
                 break;
             case 'c':

--- a/DolCon/Views/GameService.Navigation.cs
+++ b/DolCon/Views/GameService.Navigation.cs
@@ -108,10 +108,7 @@ public partial class GameService
             case 'b' when SaveGameService.CurrentBurg is null && localBurg != null:
                 moveStatus = _moveService.MoveToBurg(localBurg.i.Value) ? MoveStatus.Success : MoveStatus.Failure;
                 break;
-            case 'e' when (SaveGameService.CurrentLocation != null &&
-                           SaveGameService.CurrentLocation.Type.Size != LocationSize.unexplorable &&
-                           SaveGameService.CurrentLocation.ExploredPercent < 1) ||
-                          SaveGameService.CurrentCell.ExploredPercent < 1:
+            case 'e' when SaveGameService.CurrentLocation != null || SaveGameService.CurrentCell.ExploredPercent < 1:
                 moveStatus = _moveService.ProcessExploration();
                 if (moveStatus == MoveStatus.Success)
                 {

--- a/DolCon/Views/GameService.Navigation.cs
+++ b/DolCon/Views/GameService.Navigation.cs
@@ -21,6 +21,11 @@ public partial class GameService
 
         ProcessKey(value, localBurg);
 
+        if (!_scene.IsCompleted)
+        { 
+            RenderScene(value);
+        }
+
         currentCell = SaveGameService.CurrentCell;
         var burg = SaveGameService.CurrentBurg;
         var location = SaveGameService.CurrentLocation;
@@ -113,6 +118,9 @@ public partial class GameService
                 var thisEvent = new Event(SaveGameService.CurrentLocation, SaveGameService.CurrentCell);
                 
                 var scene = _eventService.ProcessEvent(thisEvent);
+                
+                _scene = scene;
+                _screen = Screen.Scene;
 
                 moveStatus = scene.MoveStatus;
                 message = scene.Message;

--- a/DolCon/Views/GameService.Navigation.cs
+++ b/DolCon/Views/GameService.Navigation.cs
@@ -114,22 +114,8 @@ public partial class GameService
                 
                 var scene = _eventService.ProcessEvent(thisEvent);
 
-                // moveStatus = _moveService.ProcessExploration();
                 moveStatus = scene.MoveStatus;
                 message = scene.Message;
-                // if (moveStatus == MoveStatus.Success)
-                // {
-                //     var totalCoin = 0;
-                //     foreach (var player in SaveGameService.Party.Players)
-                //     {
-                //         var random = new Chance().New();
-                //         var playerCoin = random.Dice(100) * 10;
-                //         player.coin += playerCoin;
-                //         totalCoin += playerCoin;
-                //     }
-                //
-                //     message = "You have explored the area. You have found " + totalCoin + " coin.";
-                // }
 
                 break;
             case 'c':
@@ -180,14 +166,13 @@ public partial class GameService
                 SetMessage(MessageType.Error, message);
                 break;
             case MoveStatus.None:
+            case MoveStatus.Hold:
                 message = message == string.Empty ? "Make a move." : message;
                 SetMessage(MessageType.Info, message);
                 break;
             case MoveStatus.Blocked:
                 message = message == string.Empty ? "You cannot move in that direction." : message;
                 SetMessage(MessageType.Error, message);
-                break;
-            case MoveStatus.Hold:
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(moveStatus), moveStatus, "Invalid move status.");

--- a/DolCon/Views/GameService.Navigation.cs
+++ b/DolCon/Views/GameService.Navigation.cs
@@ -149,8 +149,7 @@ public partial class GameService
                         _moveService.MoveToLocation(locationId) ? MoveStatus.Success : MoveStatus.Failure,
                     _ => MoveStatus.None
                 };
-
-
+                
                 break;
             }
         }

--- a/DolCon/Views/GameService.Scene.cs
+++ b/DolCon/Views/GameService.Scene.cs
@@ -1,5 +1,4 @@
-﻿using DolCon.Services;
-using Spectre.Console;
+﻿using Spectre.Console;
 
 namespace DolCon.Views;
 
@@ -9,14 +8,6 @@ public partial class GameService
 {
     private void RenderScene(ConsoleKeyInfo value)
     {
-        _controls.Update(
-            new Panel(
-                    Align.Center(
-                        new Markup("Select an option above."),
-                        VerticalAlignment.Middle))
-                .Expand());
-        _ctx.Refresh();
-        
         switch (_scene.Type)
         {
             case SceneType.Dialogue:
@@ -34,8 +25,6 @@ public partial class GameService
                 RenderNotReady();
                 break;
         }
-        
-        _screen = Screen.Navigation;
     }
 
     private void RenderShop(ConsoleKeyInfo value)
@@ -45,14 +34,23 @@ public partial class GameService
             var selectionTable = new Table();
             selectionTable.AddColumn("Key");
             selectionTable.AddColumn("Selection");
-            selectionTable.AddColumn("Price");
-            
-            foreach (var (key, selection) in _scene.Selections)
+            if (_scene.SelectedService is not null)
             {
-                var product = selection.Split('|');
-                selectionTable.AddRow(key.ToString(), product[0], product[1]);
+                selectionTable.AddColumn("Price");
+                foreach (var (key, selection) in _scene.Selections)
+                {
+                    var product = selection.Split('|');
+                    selectionTable.AddRow(key.ToString(), product[0], product[1]);
+                }
             }
-            
+            else
+            {
+                foreach (var (key, selection) in _scene.Selections)
+                {
+                    selectionTable.AddRow(key.ToString(), selection);
+                }
+            }
+
             _display.Update(
                 new Panel(
                     new Rows(
@@ -65,6 +63,13 @@ public partial class GameService
                         )
                     )));
             _ctx.Refresh();
+            _controls.Update(
+                new Panel(
+                        Align.Center(
+                            new Markup(_scene.Message),
+                            VerticalAlignment.Middle))
+                    .Expand());
+            _ctx.Refresh();
             var click = Console.ReadKey(true);
             var thisChar = click.KeyChar.ToString();
             var cleanChar = thisChar.First().ToString();
@@ -74,6 +79,8 @@ public partial class GameService
             _scene.Selection = choice;
             _scene = _shopService.ProcessShop(_scene);
         }
+        _screen = Screen.Navigation;
+        _scene.Reset();
     }
 
     private void RenderBattle(ConsoleKeyInfo value)

--- a/DolCon/Views/GameService.Scene.cs
+++ b/DolCon/Views/GameService.Scene.cs
@@ -1,0 +1,98 @@
+﻿using DolCon.Services;
+using Spectre.Console;
+
+namespace DolCon.Views;
+
+using Enums;
+
+public partial class GameService
+{
+    private void RenderScene(ConsoleKeyInfo value)
+    {
+        ProcessScene(value);
+        switch (_scene.Type)
+        {
+            case SceneType.Dialogue:
+                RenderDialog(value);
+                break;
+            case SceneType.Battle:
+                RenderBattle(value);
+                break;
+            case SceneType.Shop:
+                RenderShop(value);
+                break;
+            case SceneType.None:
+            default:
+                _scene.IsCompleted = true;
+                RenderNotReady();
+                break;
+        }
+
+        _controls.Update(
+            new Panel(
+                    Align.Center(
+                        new Markup("Select an option above."),
+                        VerticalAlignment.Middle))
+                .Expand());
+        _ctx.Refresh();
+    }
+
+    private void RenderShop(ConsoleKeyInfo value)
+    {
+        var thisChar = value.KeyChar.ToString();
+        var cleanChar = thisChar.First().ToString();
+        var tryParse = int.TryParse(cleanChar, out var selection);
+
+        if (tryParse)
+        {
+            _scene.SelectedService = (Service)selection;
+        }
+        
+        if (_scene.SelectedService == null)
+        {
+            var location = SaveGameService.CurrentLocation;
+            var serviceTable = new Table();
+            _display.Update(
+                new Panel(
+                    new Rows(
+                        Align.Center(
+                            new Markup($"[bold]Select a service to continue.[/]")
+                        ),
+                        Align.Center(
+                            serviceTable
+                        )
+                    )));
+            _ctx.Refresh();
+            
+            serviceTable.AddColumn("Key");
+            serviceTable.AddColumn("Service");
+
+            var services = location.Type.Services;
+            foreach (var service in services)
+            {
+                serviceTable.AddRow(((int)service).ToString(), Enum.GetName(service));
+            }
+        }
+        else
+        {
+            //TODO: Implement shop
+        }
+    }
+
+    private void RenderBattle(ConsoleKeyInfo value)
+    {
+        throw new NotImplementedException();
+    }
+
+    private void RenderDialog(ConsoleKeyInfo value)
+    {
+        throw new NotImplementedException();
+    }
+
+    private void ProcessScene(ConsoleKeyInfo value)
+    {
+        var thisChar = value.KeyChar.ToString();
+        var cleanChar = thisChar.First().ToString();
+        var tryParse = int.TryParse(cleanChar, out var selection);
+    }
+}

--- a/DolCon/Views/GameService.cs
+++ b/DolCon/Views/GameService.cs
@@ -23,12 +23,14 @@ public partial class GameService : IGameService
     private readonly IMoveService _moveService;
     private readonly IEventService _eventService;
     private Scene _scene;
+    private readonly IShopService _shopService;
 
-    public GameService(IImageService imageService, IMoveService moveService, IEventService eventService)
+    public GameService(IImageService imageService, IMoveService moveService, IEventService eventService, IShopService shopService)
     {
         _imageService = imageService;
         _moveService = moveService;
         _eventService = eventService;
+        _shopService = shopService;
     }
 
     public async Task Start(CancellationToken token)

--- a/DolCon/Views/GameService.cs
+++ b/DolCon/Views/GameService.cs
@@ -16,15 +16,17 @@ public partial class GameService : IGameService
     private Layout _message;
     private Screen _screen;
     private LiveDisplayContext _ctx;
-    private bool exiting;
+    private bool _exiting;
     
     private readonly IImageService _imageService;
     private readonly IMoveService _moveService;
+    private readonly IEventService _eventService;
 
-    public GameService(IImageService imageService, IMoveService moveService)
+    public GameService(IImageService imageService, IMoveService moveService, IEventService eventService)
     {
         _imageService = imageService;
         _moveService = moveService;
+        _eventService = eventService;
     }
 
     public async Task Start(CancellationToken token)
@@ -32,7 +34,7 @@ public partial class GameService : IGameService
         token.Register(() =>
         {
             AnsiConsole.MarkupLine("[red]Game cancelled[/]");
-            System.Environment.Exit(0);
+            Environment.Exit(0);
         });
         
         var layout = new Layout("Root")
@@ -70,7 +72,7 @@ public partial class GameService : IGameService
             var key = Console.ReadKey(true);
             if(key is { Key: ConsoleKey.E, Modifiers: ConsoleModifiers.Alt })
             {
-                exiting = true;
+                _exiting = true;
             }
             else if (Enum.IsDefined((Screen)key.Key))
             {
@@ -86,7 +88,7 @@ public partial class GameService : IGameService
                 RenderScreen(key);
             }
 
-        } while (token.IsCancellationRequested == false && !exiting);
+        } while (token.IsCancellationRequested == false && !_exiting);
     }
 
     private void ProcessHotKey(HotKeys hotKey)

--- a/DolCon/Views/GameService.cs
+++ b/DolCon/Views/GameService.cs
@@ -78,7 +78,7 @@ public partial class GameService : IGameService
             {
                 _exiting = true;
             }
-            else if (!_scene.IsCompleted)
+            else if (_scene is not null && !_scene.IsCompleted)
             {
                 _screen = Screen.Scene;
                 RenderScreen();

--- a/DolCon/Views/GameService.cs
+++ b/DolCon/Views/GameService.cs
@@ -1,6 +1,7 @@
 ﻿namespace DolCon.Views;
 
-using DolCon.Enums;
+using Models;
+using Enums;
 using Services;
 using Spectre.Console;
 
@@ -21,6 +22,7 @@ public partial class GameService : IGameService
     private readonly IImageService _imageService;
     private readonly IMoveService _moveService;
     private readonly IEventService _eventService;
+    private Scene _scene;
 
     public GameService(IImageService imageService, IMoveService moveService, IEventService eventService)
     {
@@ -74,6 +76,11 @@ public partial class GameService : IGameService
             {
                 _exiting = true;
             }
+            else if (!_scene.IsCompleted)
+            {
+                _screen = Screen.Scene;
+                RenderScreen();
+            }
             else if (Enum.IsDefined((Screen)key.Key))
             {
                 _screen = (Screen)key.Key;
@@ -114,6 +121,9 @@ public partial class GameService : IGameService
             case Screen.Navigation:
                 RenderNavigation(value);
                 break;
+            case Screen.Scene:
+                RenderScene(value);
+                break;
             case Screen.Inventory:
                 RenderNotReady();
                 break;
@@ -125,7 +135,7 @@ public partial class GameService : IGameService
                 break;
         }
     }
-    
+
     private void SetMessage(MessageType type ,string message)
     {
         var markup = type switch


### PR DESCRIPTION
- Initialize the event service
- Event and Scene POCOs
- Process e key if at a location or area is unexplored
- Add event service to game service
- Event constructor
- Process Event method
- Trigger event process on e key entry
- Scene properties
- Move processing exploration to event service
- Combine hold and none responses
- Remove exploration from Move Service
- Move to switch statement
- Build out shop scene with service selection
- Fix stamina warning
- Add shop service to app
- Bug fix
- Make UI more dynamic and driven by service
- Add price to item
- Properties to drive scene rendering
- Service to handle shops dialog
- Enable shopping
- Process key after rendering
- Navigate to scene screen
- Fix control panel
- Reset and defaults for Scene object
- Fix order of operations
