### PR TITLE
feat: unique save game files per player and map

### DIFF
--- a/DolCon.Core.Tests/SaveGameServiceTests.cs
+++ b/DolCon.Core.Tests/SaveGameServiceTests.cs
@@ -1,0 +1,77 @@
+using DolCon.Core.Services;
+using FluentAssertions;
+
+namespace DolCon.Core.Tests;
+
+public class SaveGameServiceTests
+{
+    public class SanitizePlayerNameTests
+    {
+        [Theory]
+        [InlineData("Gandalf", "Gandalf")]
+        [InlineData("Sir Lancelot", "Sir Lancelot")]
+        [InlineData("   Spaces   ", "Spaces")]
+        [InlineData("", "Unknown")]
+        [InlineData("   ", "Unknown")]
+        public void SanitizePlayerName_ReturnsExpectedResult(string input, string expected)
+        {
+            SaveGameService.SanitizePlayerName(input).Should().Be(expected);
+        }
+
+        [Fact]
+        public void SanitizePlayerName_StripsInvalidFileNameCharacters()
+        {
+            var invalidChars = Path.GetInvalidFileNameChars();
+            var input = $"Player{invalidChars[0]}Name";
+            var result = SaveGameService.SanitizePlayerName(input);
+            result.Should().Be("PlayerName");
+        }
+
+        [Fact]
+        public void SanitizePlayerName_HandlesNull()
+        {
+            SaveGameService.SanitizePlayerName(null!).Should().Be("Unknown");
+        }
+    }
+
+    public class GenerateSaveNameTests
+    {
+        [Fact]
+        public void GenerateSaveName_ReturnsMapAndPlayerName()
+        {
+            var result = SaveGameService.GenerateSaveName("mythical-world", "Gandalf", Array.Empty<string>());
+            result.Should().Be("mythical-world.Gandalf");
+        }
+
+        [Fact]
+        public void GenerateSaveName_AppendsNumber_WhenNameExists()
+        {
+            var existing = new[] { "mythical-world.Gandalf.json" };
+            var result = SaveGameService.GenerateSaveName("mythical-world", "Gandalf", existing);
+            result.Should().Be("mythical-world.Gandalf-2");
+        }
+
+        [Fact]
+        public void GenerateSaveName_FindsNextAvailableNumber()
+        {
+            var existing = new[] { "mythical-world.Gandalf.json", "mythical-world.Gandalf-2.json" };
+            var result = SaveGameService.GenerateSaveName("mythical-world", "Gandalf", existing);
+            result.Should().Be("mythical-world.Gandalf-3");
+        }
+
+        [Fact]
+        public void GenerateSaveName_SanitizesPlayerName()
+        {
+            var result = SaveGameService.GenerateSaveName("mythical-world", "  Gandalf  ", Array.Empty<string>());
+            result.Should().Be("mythical-world.Gandalf");
+        }
+
+        [Fact]
+        public void GenerateSaveName_DoesNotCollideWithDifferentMap()
+        {
+            var existing = new[] { "other-world.Gandalf.json" };
+            var result = SaveGameService.GenerateSaveName("mythical-world", "Gandalf", existing);
+            result.Should().Be("mythical-world.Gandalf");
+        }
+    }
+}

--- a/DolCon.Core/Services/SaveGameService.cs
+++ b/DolCon.Core/Services/SaveGameService.cs
@@ -9,6 +9,7 @@ public interface ISaveGameService
     Task<string> SaveGame();
     IEnumerable<FileInfo> GetSaves();
     Task LoadGame(FileInfo saveFile);
+    void DeleteSave(FileInfo saveFile);
 }
 
 public class SaveGameService : ISaveGameService
@@ -84,6 +85,12 @@ public class SaveGameService : ISaveGameService
         Party = CurrentMap.Party;
         CurrentPlayerId = CurrentMap.CurrentPlayerId;
         CurrentSaveName = Path.GetFileNameWithoutExtension(saveFile.Name);
+    }
+
+    public void DeleteSave(FileInfo saveFile)
+    {
+        if (saveFile.Exists)
+            saveFile.Delete();
     }
 
     public static Cell GetCell(int cellId)

--- a/DolCon.Core/Services/SaveGameService.cs
+++ b/DolCon.Core/Services/SaveGameService.cs
@@ -83,6 +83,7 @@ public class SaveGameService : ISaveGameService
         CurrentMap = map ?? throw new DolSaveGameException("Failed to load game");
         Party = CurrentMap.Party;
         CurrentPlayerId = CurrentMap.CurrentPlayerId;
+        CurrentSaveName = Path.GetFileNameWithoutExtension(saveFile.Name);
     }
 
     public static Cell GetCell(int cellId)

--- a/DolCon.Core/Services/SaveGameService.cs
+++ b/DolCon.Core/Services/SaveGameService.cs
@@ -38,6 +38,8 @@ public class SaveGameService : ISaveGameService
 
     public static string CurrentBiome => CurrentMap.biomes.name[CurrentCell.biome];
 
+    public static string? CurrentSaveName { get; set; }
+
     private readonly string _savesPath;
 
     public SaveGameService()
@@ -96,5 +98,30 @@ public class SaveGameService : ISaveGameService
     public static State GetState(int cellState)
     {
         return CurrentMap.Collections.states[cellState];
+    }
+
+    public static string SanitizePlayerName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "Unknown";
+
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var sanitized = new string(name.Where(c => !invalidChars.Contains(c)).ToArray()).Trim();
+
+        return string.IsNullOrWhiteSpace(sanitized) ? "Unknown" : sanitized;
+    }
+
+    public static string GenerateSaveName(string mapName, string playerName, string[] existingFileNames)
+    {
+        var sanitized = SanitizePlayerName(playerName);
+        var baseName = $"{mapName}.{sanitized}";
+
+        if (!existingFileNames.Contains($"{baseName}.json"))
+            return baseName;
+
+        var counter = 2;
+        while (existingFileNames.Contains($"{baseName}-{counter}.json"))
+            counter++;
+
+        return $"{baseName}-{counter}";
     }
 }

--- a/DolCon.MonoGame/Screens/CharacterCreationScreen.cs
+++ b/DolCon.MonoGame/Screens/CharacterCreationScreen.cs
@@ -236,7 +236,7 @@ public class CharacterCreationScreen : ScreenBase
         var existingFiles = _saveGameService.GetSaves()
             .Select(f => f.Name).ToArray();
         var mapName = SaveGameService.CurrentMap.info?.mapName ?? "unknown";
-        var sanitizedName = SaveGameService.SanitizePlayerName(_playerName.Trim());
+        var sanitizedName = SaveGameService.SanitizeFileComponent(_playerName.Trim());
         SaveGameService.CurrentSaveName = SaveGameService.GenerateSaveName(
             mapName, sanitizedName, existingFiles);
 

--- a/DolCon.MonoGame/Screens/CharacterCreationScreen.cs
+++ b/DolCon.MonoGame/Screens/CharacterCreationScreen.cs
@@ -233,6 +233,13 @@ public class CharacterCreationScreen : ScreenBase
     {
         _mapService.LoadMap(_selectedMap, _playerName.Trim(), _abilities);
 
+        var existingFiles = _saveGameService.GetSaves()
+            .Select(f => f.Name).ToArray();
+        var mapName = SaveGameService.CurrentMap.info?.mapName ?? "unknown";
+        var sanitizedName = SaveGameService.SanitizePlayerName(_playerName.Trim());
+        SaveGameService.CurrentSaveName = SaveGameService.GenerateSaveName(
+            mapName, sanitizedName, existingFiles);
+
         var path = _saveGameService.SaveGame().Result;
         _saveGameService.LoadGame(new FileInfo(path)).Wait();
 

--- a/DolCon.MonoGame/Screens/MainMenuScreen.cs
+++ b/DolCon.MonoGame/Screens/MainMenuScreen.cs
@@ -39,6 +39,7 @@ public class MainMenuScreen : ScreenBase
         _selectedIndex = 0;
         _state = MenuState.MainMenu;
         _statusMessage = "";
+        SaveGameService.CurrentSaveName = null;
     }
 
     public override void Update(GameTime gameTime, InputManager input)
@@ -176,7 +177,12 @@ public class MainMenuScreen : ScreenBase
                 break;
             case MenuState.SelectSave:
                 DrawCenteredText(spriteBatch, "Select a Save", 150, Color.White);
-                var saveNames = _availableSaves.Select(s => s.Name).ToArray();
+                var saveNames = _availableSaves.Select(s =>
+                {
+                    var name = Path.GetFileNameWithoutExtension(s.Name);
+                    var parts = name.Split('.', 2);
+                    return parts.Length == 2 ? $"{parts[1]} ({parts[0]})" : name;
+                }).ToArray();
                 DrawMenu(spriteBatch, saveNames, centerX, startY);
                 DrawCenteredText(spriteBatch, "Press ESC to go back", 500, Color.Gray);
                 break;

--- a/DolCon.MonoGame/Screens/MainMenuScreen.cs
+++ b/DolCon.MonoGame/Screens/MainMenuScreen.cs
@@ -210,20 +210,14 @@ public class MainMenuScreen : ScreenBase
                 break;
             case MenuState.SelectSave:
                 DrawCenteredText(spriteBatch, "Select a Save", 150, Color.White);
-                var saveNames = _availableSaves.Select(s =>
-                {
-                    var name = Path.GetFileNameWithoutExtension(s.Name);
-                    var parts = name.Split('.', 2);
-                    return parts.Length == 2 ? $"{parts[1]} ({parts[0]})" : name;
-                }).ToArray();
+                var saveNames = _availableSaves
+                    .Select(s => SaveGameService.FormatSaveDisplayName(s.Name)).ToArray();
                 DrawMenu(spriteBatch, saveNames, centerX, startY);
                 DrawCenteredText(spriteBatch, "[X] Delete  |  [ESC] Back", 500, Color.Gray);
                 break;
             case MenuState.ConfirmDelete:
                 DrawCenteredText(spriteBatch, "Delete Save?", 150, Color.Red);
-                var deleteName = Path.GetFileNameWithoutExtension(_availableSaves[_selectedIndex].Name);
-                var deleteParts = deleteName.Split('.', 2);
-                var displayName = deleteParts.Length == 2 ? $"{deleteParts[1]} ({deleteParts[0]})" : deleteName;
+                var displayName = SaveGameService.FormatSaveDisplayName(_availableSaves[_selectedIndex].Name);
                 DrawCenteredText(spriteBatch, displayName, startY, Color.Yellow);
                 DrawCenteredText(spriteBatch, "[ENTER] Confirm  |  [ESC] Cancel", 500, Color.Gray);
                 break;


### PR DESCRIPTION
## Summary
- Save files now use `{mapName}.{playerName}.json` naming instead of `{mapName}.AutoSave.json`, preventing overwrites when starting new games
- Added save file deletion with confirmation flow (press [X] to delete, [ENTER] to confirm)
- Load game screen displays saves as "PlayerName (mapName)" instead of raw filenames

## Changes
- **SaveGameService**: Added `CurrentSaveName` tracking, `SanitizePlayerName()`, `GenerateSaveName()` with collision handling (`-2`, `-3` suffixes), and `DeleteSave()` method
- **CharacterCreationScreen**: Generates unique save name before first save
- **MainMenuScreen**: Improved save display, delete confirmation state, reset save name on menu return
- **Tests**: 12 new unit tests for name sanitization and unique name generation

## Test plan
- [x] All 260 tests pass
- [x] Solution builds cleanly
- [x] Manual: start new game, verify save file named `{map}.{player}.json`
- [x] Manual: start second game with same map/different name, verify first save preserved
- [x] Manual: start second game with same map/same name, verify collision suffix applied
- [x] Manual: load game, verify subsequent auto-saves go to same file
- [x] Manual: delete a save from the load game screen
- [x] Manual: load an old `AutoSave` file, verify backward compatibility

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)