### PR TITLE
Phase 0 — Define the world.dol canonical schema (#73)

### DIFF
--- a/DolCon.Core.Tests/World/DolWorldSerializationTests.cs
+++ b/DolCon.Core.Tests/World/DolWorldSerializationTests.cs
@@ -1,0 +1,180 @@
+namespace DolCon.Core.Tests.World;
+
+using DolCon.Core.Enums;
+using DolCon.Core.Models;
+using DolCon.Core.Models.World;
+using FluentAssertions;
+
+public class DolWorldSerializationTests
+{
+    private static DolWorld BuildSampleWorld(bool withEnrichment)
+    {
+        var world = new DolWorld
+        {
+            Info = new WorldInfo
+            {
+                Name = "Test World",
+                SourceSeed = "123456",
+                SourceAzgaarVersion = "1.99",
+                GeneratedAt = new DateTime(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc),
+                GeneratorVersion = "0.1.0"
+            },
+            Coords = new WorldCoords { LatT = 90, LatN = 60, LatS = 20, LonT = 180, LonW = -40, LonE = 40 },
+            Vertices = new List<WorldVertex>
+            {
+                new() { P = new[] { 0.0, 0.0 } },
+                new() { P = new[] { 10.0, 0.0 } },
+                new() { P = new[] { 5.0, 10.0 } }
+            },
+            Biomes = new List<string> { "Marine", "Hot desert", "Temperate deciduous forest" },
+            States = new List<WorldState> { new() { Id = 1, Name = "Aurelia", FullName = "Kingdom of Aurelia" } },
+            Provinces = new List<WorldProvince> { new() { Id = 1, Name = "Dawnmoor", FullName = "Province of Dawnmoor" } },
+            Rivers = new List<WorldRiver>
+            {
+                new() { Id = 1, Name = "Silverflow", Cells = new List<int> { 0, 1 }, Width = 2.5, Length = 40, Source = 0, Mouth = 1 }
+            },
+            Cells = new List<WorldCell>
+            {
+                new()
+                {
+                    Id = 0,
+                    VertexIndices = new List<int> { 0, 1, 2 },
+                    Neighbors = new List<int> { 1 },
+                    Center = new[] { 5.0, 3.0 },
+                    Area = 120,
+                    Pop = 4.2m,
+                    Biome = 2,
+                    State = 1,
+                    Province = 1,
+                    Burg = 1,
+                    ChallengeRating = 0.0,
+                    Locations = new List<WorldLocation>
+                    {
+                        new() { Id = Guid.NewGuid(), Name = "ruins", TypeKey = "ruins", Rarity = Rarity.Uncommon }
+                    }
+                },
+                new()
+                {
+                    Id = 1,
+                    VertexIndices = new List<int> { 1, 2, 0 },
+                    Neighbors = new List<int> { 0 },
+                    Center = new[] { 8.0, 6.0 },
+                    Area = 80,
+                    Pop = 0.0m,
+                    Biome = 1,
+                    State = 1,
+                    Province = 1,
+                    Burg = 0,
+                    ChallengeRating = 4.5
+                }
+            },
+            Burgs = new List<WorldBurg>
+            {
+                new()
+                {
+                    Id = 1,
+                    Name = "Lumengarde",
+                    Cell = 0,
+                    Population = 1050,
+                    Size = BurgSize.City,
+                    IsCityOfLight = true,
+                    X = 5.0,
+                    Y = 3.0,
+                    HasPort = true,
+                    HasTemple = true,
+                    Locations = new List<WorldLocation>
+                    {
+                        new() { Id = Guid.NewGuid(), Name = "Lumengarde tavern", TypeKey = "tavern", Rarity = Rarity.Common }
+                    }
+                }
+            }
+        };
+
+        if (withEnrichment)
+        {
+            world.Enrichment = new Enrichment
+            {
+                Status = EnrichmentStatus.Draft,
+                History = new List<HistoryEvent>
+                {
+                    new() { Title = "The Sundering", Era = "First Age", Description = "The world split." }
+                },
+                Notes = "Seed lore here."
+            };
+            world.Burgs[0].Enrichment = new Enrichment
+            {
+                Status = EnrichmentStatus.Authored,
+                Npcs = new List<Npc>
+                {
+                    new() { Id = "npc-1", Name = "Mayor Voss", Role = "Mayor", Description = "Stern but fair." }
+                },
+                Assets = new List<AssetRef>
+                {
+                    new() { Key = "lumengarde-banner", Kind = "icon", Spec = "A radiant sunburst banner.", Status = EnrichmentStatus.Draft }
+                }
+            };
+        }
+
+        return world;
+    }
+
+    [Fact]
+    public void DolWorld_FullRoundTrip_IsLossless()
+    {
+        // Arrange
+        var world = BuildSampleWorld(withEnrichment: true);
+
+        // Act
+        var json = DolWorldSerializer.Serialize(world);
+        var restored = DolWorldSerializer.Deserialize(json);
+
+        // Assert
+        restored.Should().BeEquivalentTo(world);
+    }
+
+    [Fact]
+    public void DolWorld_MinimalWorldWithoutEnrichment_OmitsNullContainersAndRoundTrips()
+    {
+        // Arrange
+        var world = BuildSampleWorld(withEnrichment: false);
+
+        // Act
+        var json = DolWorldSerializer.Serialize(world);
+        var restored = DolWorldSerializer.Deserialize(json);
+
+        // Assert
+        json.Should().NotContain("\"enrichment\"");
+        restored.Should().BeEquivalentTo(world);
+    }
+
+    [Fact]
+    public void DolWorld_Serializes_WithHumanReadableEnumsAndSchemaVersion()
+    {
+        // Arrange
+        var world = BuildSampleWorld(withEnrichment: true);
+
+        // Act
+        var json = DolWorldSerializer.Serialize(world);
+
+        // Assert
+        json.Should().Contain("\"schemaVersion\": 1");
+        json.Should().Contain("\"size\": \"City\"");
+        json.Should().Contain("\"status\": \"Draft\"");
+        json.Should().Contain("\"rarity\": \"Common\"");
+    }
+
+    [Fact]
+    public void WorldLocation_TypeKey_RehydratesFromLocationTypesCatalog()
+    {
+        // Arrange
+        var world = BuildSampleWorld(withEnrichment: false);
+        var bakedLocation = world.Burgs[0].Locations[0];
+
+        // Act
+        var locationType = LocationTypes.Types.FirstOrDefault(t => t.Type == bakedLocation.TypeKey);
+
+        // Assert
+        locationType.Should().NotBeNull();
+        locationType!.Type.Should().Be("tavern");
+    }
+}

--- a/DolCon.Core/Models/World/DolWorld.cs
+++ b/DolCon.Core/Models/World/DolWorld.cs
@@ -1,0 +1,61 @@
+namespace DolCon.Core.Models.World;
+
+/// <summary>
+/// Canonical, baked "Dominion of Light" world (<c>world.dol</c>). Produced once by WorldForge from
+/// an Azgaar export and loaded by the game instead of re-provisioning at runtime. Contains the
+/// Azgaar subset the game actually reads, the provisioning that used to be re-rolled each play
+/// (City of Light, challenge ratings, locations, burg sizes), and reserved enrichment containers.
+/// Per-playthrough progress (exploration/discovery) is NOT stored here — that lives in the save game.
+/// See <c>docs/WORLD_DOL_FORMAT.md</c>.
+/// </summary>
+public class DolWorld
+{
+    /// <summary>Format version on the root so baked worlds can evolve without breaking. Starts at 1.</summary>
+    public int SchemaVersion { get; set; } = 1;
+
+    public WorldInfo Info { get; set; } = new();
+    public WorldCoords Coords { get; set; } = new();
+
+    /// <summary>Shared vertex pool; cells reference these by index for polygon rendering.</summary>
+    public List<WorldVertex> Vertices { get; set; } = new();
+
+    public List<WorldCell> Cells { get; set; } = new();
+    public List<WorldBurg> Burgs { get; set; } = new();
+    public List<WorldState> States { get; set; } = new();
+    public List<WorldProvince> Provinces { get; set; } = new();
+    public List<WorldRiver> Rivers { get; set; } = new();
+
+    /// <summary>Biome-name lookup table; cell <c>Biome</c> indexes into this list.</summary>
+    public List<string> Biomes { get; set; } = new();
+
+    /// <summary>World-level reserved enrichment (global history, NPCs). Optional; omitted when null.</summary>
+    public Enrichment? Enrichment { get; set; }
+}
+
+/// <summary>Provenance/metadata for a baked world.</summary>
+public class WorldInfo
+{
+    public string Name { get; set; } = null!;
+    public string? SourceSeed { get; set; }
+    public string? SourceAzgaarVersion { get; set; }
+    public DateTime GeneratedAt { get; set; }
+    public string? GeneratorVersion { get; set; }
+}
+
+/// <summary>Geographic bounds carried over from the Azgaar export (reserved for future rendering).</summary>
+public class WorldCoords
+{
+    public double LatT { get; set; }
+    public double LatN { get; set; }
+    public double LatS { get; set; }
+    public double LonT { get; set; }
+    public double LonW { get; set; }
+    public double LonE { get; set; }
+}
+
+/// <summary>A map vertex. Only the coordinate pair is needed for polygon rendering.</summary>
+public class WorldVertex
+{
+    /// <summary>Coordinate pair [x, y].</summary>
+    public double[] P { get; set; } = System.Array.Empty<double>();
+}

--- a/DolCon.Core/Models/World/DolWorldSerializer.cs
+++ b/DolCon.Core/Models/World/DolWorldSerializer.cs
@@ -1,0 +1,25 @@
+namespace DolCon.Core.Models.World;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Single source of truth for how <c>world.dol</c> is serialized. WorldForge (the baker) and the
+/// game (the loader) both go through here so the format is identical on both sides: camelCase
+/// property names, enums written as human-readable strings, indented, and null containers omitted —
+/// keeping baked worlds pleasant to author by hand or by an AI agent.
+/// </summary>
+public static class DolWorldSerializer
+{
+    public static JsonSerializerOptions Options { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public static string Serialize(DolWorld world) => JsonSerializer.Serialize(world, Options);
+
+    public static DolWorld? Deserialize(string json) => JsonSerializer.Deserialize<DolWorld>(json, Options);
+}

--- a/DolCon.Core/Models/World/Enrichment.cs
+++ b/DolCon.Core/Models/World/Enrichment.cs
@@ -1,0 +1,67 @@
+namespace DolCon.Core.Models.World;
+
+/// <summary>
+/// Authoring/worklist state of an <see cref="Enrichment"/> block. Driven by the Phase 3 (#76)
+/// flag/todo system. <see cref="Empty"/> means nothing has been authored yet.
+/// </summary>
+public enum EnrichmentStatus
+{
+    Empty,
+    Draft,
+    Authored,
+    Reviewed
+}
+
+/// <summary>
+/// Reserved, AI-friendly container for authored content attached to a world object
+/// (world / cell / burg / location). Empty by default so a world can be baked with no authored
+/// content. Phases 3–5 (#76–#78) populate these. The whole block is optional (nullable) on every
+/// object and omitted from JSON when null.
+/// </summary>
+public class Enrichment
+{
+    public EnrichmentStatus Status { get; set; } = EnrichmentStatus.Empty;
+    public List<Npc> Npcs { get; set; } = new();
+    public List<HistoryEvent> History { get; set; } = new();
+    public List<PointOfInterest> PointsOfInterest { get; set; } = new();
+    public List<AssetRef> Assets { get; set; } = new();
+    public string? Notes { get; set; }
+}
+
+/// <summary>Minimal NPC placeholder; expanded in Phase 4 (#77).</summary>
+public class Npc
+{
+    public string Id { get; set; } = null!;
+    public string Name { get; set; } = null!;
+    public string? Role { get; set; }
+    public string? Description { get; set; }
+}
+
+/// <summary>Minimal history-event placeholder; expanded in Phase 4 (#77).</summary>
+public class HistoryEvent
+{
+    public string Title { get; set; } = null!;
+    public string? Era { get; set; }
+    public string? Description { get; set; }
+}
+
+/// <summary>Minimal point-of-interest placeholder; expanded in Phase 4 (#77).</summary>
+public class PointOfInterest
+{
+    public string Name { get; set; } = null!;
+    public string? Kind { get; set; }
+    public string? Description { get; set; }
+}
+
+/// <summary>
+/// Reference to an external visual asset. The AI authors the <see cref="Spec"/> (prompt/spec);
+/// the actual art is procured externally and its <see cref="Path"/> filled in later (Phase 5, #78).
+/// </summary>
+public class AssetRef
+{
+    public string Key { get; set; } = null!;
+    public string? Kind { get; set; }
+    public string? Spec { get; set; }
+    public string? Path { get; set; }
+    public EnrichmentStatus Status { get; set; } = EnrichmentStatus.Empty;
+}

--- a/DolCon.Core/Models/World/WorldBurg.cs
+++ b/DolCon.Core/Models/World/WorldBurg.cs
@@ -1,0 +1,42 @@
+namespace DolCon.Core.Models.World;
+
+using Enums;
+
+/// <summary>
+/// A settlement. Population and <see cref="Size"/> are the baked (adjusted) values, and
+/// <see cref="IsCityOfLight"/> plus the generated locations are baked rather than re-rolled.
+/// The feature booleans are converted from Azgaar's nullable 0/1 flags.
+/// </summary>
+public class WorldBurg
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = null!;
+
+    /// <summary>Id of the cell this burg sits in.</summary>
+    public int Cell { get; set; }
+
+    /// <summary>Adjusted population (baked).</summary>
+    public double Population { get; set; }
+
+    /// <summary>Size category derived from the adjusted population (baked).</summary>
+    public BurgSize Size { get; set; }
+
+    /// <summary>Whether this is the world's single City of Light (baked).</summary>
+    public bool IsCityOfLight { get; set; }
+
+    public double? X { get; set; }
+    public double? Y { get; set; }
+
+    public bool HasPort { get; set; }
+    public bool HasCitadel { get; set; }
+    public bool HasPlaza { get; set; }
+    public bool HasWalls { get; set; }
+    public bool HasShanty { get; set; }
+    public bool HasTemple { get; set; }
+
+    /// <summary>Baked, generated locations for this burg.</summary>
+    public List<WorldLocation> Locations { get; set; } = new();
+
+    /// <summary>Reserved enrichment for this burg. Optional; omitted when null.</summary>
+    public Enrichment? Enrichment { get; set; }
+}

--- a/DolCon.Core/Models/World/WorldCell.cs
+++ b/DolCon.Core/Models/World/WorldCell.cs
@@ -1,0 +1,43 @@
+namespace DolCon.Core.Models.World;
+
+/// <summary>
+/// A Voronoi cell of the world. Holds the Azgaar geometry the game renders/navigates plus the
+/// baked challenge rating and generated locations that used to be re-rolled at runtime.
+/// </summary>
+public class WorldCell
+{
+    public int Id { get; set; }
+
+    /// <summary>Indices into <see cref="DolWorld.Vertices"/> forming this cell's polygon (Azgaar <c>v</c>).</summary>
+    public List<int> VertexIndices { get; set; } = new();
+
+    /// <summary>Neighboring cell ids (Azgaar <c>c</c>).</summary>
+    public List<int> Neighbors { get; set; } = new();
+
+    /// <summary>Cell center [x, y] (Azgaar <c>p</c>).</summary>
+    public double[] Center { get; set; } = System.Array.Empty<double>();
+
+    /// <summary>Cell area; drives the derived <c>CellSize</c>.</summary>
+    public int Area { get; set; }
+
+    /// <summary>Population; drives the derived <c>PopDensity</c>.</summary>
+    public decimal Pop { get; set; }
+
+    /// <summary>Biome index into <see cref="DolWorld.Biomes"/>.</summary>
+    public int Biome { get; set; }
+
+    public int State { get; set; }
+    public int Province { get; set; }
+
+    /// <summary>Burg id located in this cell, or 0 if none.</summary>
+    public int Burg { get; set; }
+
+    /// <summary>Baked encounter difficulty (was computed from distance to the City of Light).</summary>
+    public double ChallengeRating { get; set; }
+
+    /// <summary>Baked, generated locations for this cell.</summary>
+    public List<WorldLocation> Locations { get; set; } = new();
+
+    /// <summary>Reserved enrichment for this cell. Optional; omitted when null.</summary>
+    public Enrichment? Enrichment { get; set; }
+}

--- a/DolCon.Core/Models/World/WorldLocation.cs
+++ b/DolCon.Core/Models/World/WorldLocation.cs
@@ -1,0 +1,28 @@
+namespace DolCon.Core.Models.World;
+
+using Enums;
+
+/// <summary>
+/// A baked location definition placed on a cell or burg. Stores only the static identity — the
+/// full <c>LocationType</c> template is rehydrated at load time from the <c>LocationTypes.Types</c>
+/// catalog via <see cref="TypeKey"/>. Per-playthrough exploration/discovery state is NOT stored
+/// here; it lives in the save game.
+/// </summary>
+public class WorldLocation
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Key into the static <c>LocationTypes.Types</c> catalog (the unique <c>LocationType.Type</c>,
+    /// e.g. <c>"tavern"</c>). Keeps the world file slim instead of embedding the whole template.
+    /// </summary>
+    public string TypeKey { get; set; } = null!;
+
+    /// <summary>The rolled instance rarity (within the type's rarity range), so it must be persisted.</summary>
+    public Rarity Rarity { get; set; }
+
+    /// <summary>Reserved enrichment for this location. Optional; omitted when null.</summary>
+    public Enrichment? Enrichment { get; set; }
+}

--- a/DolCon.Core/Models/World/WorldProvince.cs
+++ b/DolCon.Core/Models/World/WorldProvince.cs
@@ -1,0 +1,12 @@
+namespace DolCon.Core.Models.World;
+
+/// <summary>
+/// A province. <see cref="FullName"/> is the field the navigation UI displays; the rest of Azgaar's
+/// province data (heraldry, color, centers) is dropped.
+/// </summary>
+public class WorldProvince
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string FullName { get; set; } = null!;
+}

--- a/DolCon.Core/Models/World/WorldRiver.cs
+++ b/DolCon.Core/Models/World/WorldRiver.cs
@@ -1,0 +1,19 @@
+namespace DolCon.Core.Models.World;
+
+/// <summary>
+/// A river. Not read by current game logic, but retained (slimmed) per the issue scope for future
+/// map rendering. The Azgaar discharge/basin/widthFactor fields are dropped.
+/// </summary>
+public class WorldRiver
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = null!;
+
+    /// <summary>Cell ids the river flows through.</summary>
+    public List<int> Cells { get; set; } = new();
+
+    public double Width { get; set; }
+    public double Length { get; set; }
+    public int Source { get; set; }
+    public int Mouth { get; set; }
+}

--- a/DolCon.Core/Models/World/WorldState.cs
+++ b/DolCon.Core/Models/World/WorldState.cs
@@ -1,0 +1,12 @@
+namespace DolCon.Core.Models.World;
+
+/// <summary>
+/// A nation/state. Minimal — the game only ever surfaces names — but kept indexable for display
+/// and future use. The bulk of Azgaar's state data (military, campaigns, diplomacy, heraldry) is dropped.
+/// </summary>
+public class WorldState
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? FullName { get; set; }
+}

--- a/docs/WORLD_DOL_FORMAT.md
+++ b/docs/WORLD_DOL_FORMAT.md
@@ -1,0 +1,194 @@
+# The `world.dol` Canonical World Format
+
+`world.dol` is the **baked, canonical "Dominion of Light" world** that
+[WorldForge](https://github.com/bcolemutech/dol-con-v2/issues/72) produces from an
+[Azgaar Fantasy-Map-Generator](https://github.com/Azgaar/Fantasy-Map-Generator) export, and that the
+game loads at runtime. It replaces the old flow where the game parsed the full raw Azgaar JSON and
+re-provisioned the world (City of Light, challenge ratings, locations, burg sizes) every playthrough
+with a non-seeded `new Random()`.
+
+This document describes the **schema contract** defined in Phase 0 (#73). It is the foundation the
+later phases build on:
+
+- **Phase 1 (#74):** WorldForge bakes an Azgaar export into a `world.dol`.
+- **Phase 2 (#75):** the game loads `world.dol` and retires runtime provisioning.
+- **Phases 3–5 (#76–#78):** AI-assisted enrichment fills the reserved containers described below.
+
+## Where the model lives
+
+All types live in `DolCon.Core/Models/World/` so both WorldForge and the game reference one
+definition. The root is `DolWorld`. Serialization goes through `DolWorldSerializer`, which is the
+**single source of truth** for the JSON options — both the baker and the loader must use it.
+
+## Serialization
+
+- **Library:** `System.Text.Json`.
+- **Options (`DolWorldSerializer.Options`):**
+  - `PropertyNamingPolicy = CamelCase` — `ChallengeRating` → `challengeRating`.
+  - `JsonStringEnumConverter` — enums are written as **human-readable strings** (`"size": "City"`,
+    `"rarity": "Common"`, `"status": "Authored"`), never integers.
+  - `WriteIndented = true` — pretty-printed.
+  - `DefaultIgnoreCondition = WhenWritingNull` — null containers (e.g. an absent `enrichment` block)
+    are omitted entirely.
+
+These choices keep a baked world **pleasant to author or edit by hand or by an AI agent**, which
+phases 3–5 rely on.
+
+## Versioning strategy
+
+The root carries `schemaVersion` (currently **`1`**).
+
+- Add the field to every baked world.
+- **Additive, backward-compatible changes** (new optional fields, new enrichment types) do **not**
+  bump the version — older worlds still deserialize because missing properties fall back to defaults.
+- **Breaking changes** (renames, removals, semantic changes) bump `schemaVersion`. Loaders should
+  read the version first and migrate or reject worlds they don't understand.
+
+## What the schema contains
+
+The schema is deliberately three things and nothing else:
+
+### 1. The Azgaar subset the game actually reads
+
+Audited from `DolCon.Core/Models/BaseTypes/` against every service and screen — only fields the game
+consumes survive.
+
+| `DolWorld` member | Source (Azgaar `Map`) | Notes |
+| --- | --- | --- |
+| `vertices[].p` | `vertices[].p` | Cell-polygon rendering. |
+| `cells[].id / vertexIndices / neighbors / center` | cell `i / v / c / p` | Geometry + navigation. |
+| `cells[].area / pop / biome` | cell `area / pop / biome` | Feed derived `CellSize` / `PopDensity` / `Biome`. |
+| `cells[].state / province / burg` | cell `state / province / burg` | Lookups into the lists below. |
+| `burgs[].id / name / cell / x / y` | burg `i / name / cell / x / y` | Identity + map placement. |
+| `burgs[].hasPort / hasCitadel / hasPlaza / hasWalls / hasShanty / hasTemple` | burg `port / citadel / plaza / walls / shanty / temple` (nullable 0/1 → bool) | Settlement features. |
+| `states[].id / name / fullName` | state `i / name / fullName` | Minimal; the game only surfaces names. |
+| `provinces[].id / name / fullName` | province `i / name / fullName` | `fullName` is what the nav UI shows. |
+| `rivers[]` (slim) | rivers | Not read today; retained for future rendering. |
+| `coords` | coords | Retained for future rendering. |
+| `biomes[]` | `biomes.name[]` | Biome-name lookup table. |
+
+### 2. Provisioning baked in (was re-rolled each play)
+
+These used to be computed in `MapService.ProvisionMap()` and thrown away. They are now part of the
+canonical world:
+
+| `DolWorld` member | Replaces runtime computation |
+| --- | --- |
+| `burgs[].isCityOfLight` | Highest-population burg flagged as the City of Light. |
+| `cells[].challengeRating` | Encounter difficulty from distance to the City of Light. |
+| `cells[].locations` / `burgs[].locations` | Generated `Location`s. |
+| `burgs[].population` / `burgs[].size` | Adjusted population and resulting `BurgSize`. |
+
+**Locations are stored by reference, not by value.** A `WorldLocation` keeps only `id`, `name`,
+`typeKey`, and the rolled `rarity`. `typeKey` is the unique `LocationType.Type` string (e.g.
+`"tavern"`); the full template is rehydrated at load time from the static `LocationTypes.Types`
+catalog. This keeps the file slim and avoids duplicating the catalog into every location.
+
+### 3. Reserved enrichment containers (empty for now)
+
+Every enrichable object (`DolWorld`, `WorldCell`, `WorldBurg`, `WorldLocation`) has an **optional**
+`enrichment` block. It is `null`/omitted by default, so Phase 1 can bake a fully valid world with no
+authored content. Phases 3–5 fill it.
+
+- `status` — `EnrichmentStatus` (`Empty` | `Draft` | `Authored` | `Reviewed`); the per-object
+  flag/worklist marker Phase 3 drives.
+- `npcs`, `history`, `pointsOfInterest` — AI-friendly content lists (minimal placeholder shapes for
+  now, expanded in Phase 4).
+- `assets` — references to **external** art. The AI authors the `spec` (prompt/spec) and manages the
+  manifest; the actual image is procured externally and its `path` filled in later (Phase 5).
+- `notes` — free-form authoring notes.
+
+## What was deliberately dropped vs. the raw Azgaar export
+
+The game never reads these, so they are **not** in `world.dol`:
+
+- **Heraldry:** `Coa`, `Charge`, `Ordinary`, `Division`.
+- **Biome detail:** `biomesMartix`, `habitability`, `iconsDensity`, `icons`, `cost` (only the
+  name lookup is kept).
+- **Generation helpers:** `nameBases`, `cultures`.
+- **Unused state data:** `military` / `U`, `campaigns`, `diplomacy`, `neighbors`, `pole`, plus
+  `markers`, and most of `settings` / `options`.
+- **Unused cell fields:** `g`, `h`, `f`, `t`, `haven`, `harbor`, `fl`, `r`, `conf`, `s`, `culture`,
+  `road`, `crossroad`.
+- **Unused burg fields:** `feature`, `capital`, `type`, `coa`.
+
+It also deliberately **excludes per-playthrough player progress**. The canonical world is immutable;
+exploration/discovery state (`ExploredPercent`, `Discovered`, `LastExplored`) and player/party data
+(`Party`, `CurrentPlayerId`) live in the **save game**, not in `world.dol`.
+
+## Example
+
+A trimmed `world.dol` (one cell, one burg with an authored enrichment block):
+
+```json
+{
+  "schemaVersion": 1,
+  "info": {
+    "name": "Sample World",
+    "sourceSeed": "123456",
+    "sourceAzgaarVersion": "1.99",
+    "generatedAt": "2026-06-28T12:00:00Z",
+    "generatorVersion": "0.1.0"
+  },
+  "coords": { "latT": 90, "latN": 60, "latS": 20, "lonT": 180, "lonW": -40, "lonE": 40 },
+  "vertices": [ { "p": [0, 0] }, { "p": [10, 0] }, { "p": [5, 10] } ],
+  "cells": [
+    {
+      "id": 0,
+      "vertexIndices": [0, 1, 2],
+      "neighbors": [1],
+      "center": [5, 3],
+      "area": 120,
+      "pop": 4.2,
+      "biome": 2,
+      "state": 1,
+      "province": 1,
+      "burg": 1,
+      "challengeRating": 0,
+      "locations": [
+        { "id": "11111111-1111-1111-1111-111111111111", "name": "ruins", "typeKey": "ruins", "rarity": "Uncommon" }
+      ]
+    }
+  ],
+  "burgs": [
+    {
+      "id": 1,
+      "name": "Lumengarde",
+      "cell": 0,
+      "population": 1050,
+      "size": "City",
+      "isCityOfLight": true,
+      "x": 5,
+      "y": 3,
+      "hasPort": true,
+      "hasCitadel": false,
+      "hasPlaza": false,
+      "hasWalls": false,
+      "hasShanty": false,
+      "hasTemple": true,
+      "locations": [
+        { "id": "22222222-2222-2222-2222-222222222222", "name": "Lumengarde tavern", "typeKey": "tavern", "rarity": "Common" }
+      ],
+      "enrichment": {
+        "status": "Authored",
+        "npcs": [ { "id": "npc-1", "name": "Mayor Voss", "role": "Mayor", "description": "Stern but fair." } ],
+        "history": [],
+        "pointsOfInterest": [],
+        "assets": [
+          { "key": "lumengarde-banner", "kind": "icon", "spec": "A radiant sunburst banner.", "status": "Draft" }
+        ]
+      }
+    }
+  ],
+  "states": [ { "id": 1, "name": "Aurelia", "fullName": "Kingdom of Aurelia" } ],
+  "provinces": [ { "id": 1, "name": "Dawnmoor", "fullName": "Province of Dawnmoor" } ],
+  "rivers": [ { "id": 1, "name": "Silverflow", "cells": [0, 1], "width": 2.5, "length": 40, "source": 0, "mouth": 1 } ],
+  "biomes": ["Marine", "Hot desert", "Temperate deciduous forest"]
+}
+```
+
+## Tests
+
+Round-trip coverage lives in `DolCon.Core.Tests/World/DolWorldSerializationTests.cs`: a full
+lossless round-trip (`serialize → deserialize → BeEquivalentTo`), a minimal world that omits null
+enrichment, human-readable enum + `schemaVersion` assertions, and `typeKey` catalog rehydration.


### PR DESCRIPTION
Closes #73. First, foundational phase of the WorldForge epic (#72): define the canonical, baked `world.dol` contract that WorldForge will produce and the game will consume. **Schema + docs + tests only** — no WorldForge tool, no game wiring, no behavior change yet (those are Phases 1–2, #74/#75).

## What's in it

New `DolWorld` model in `DolCon.Core/Models/World/`, holding exactly three things:

1. **The audited Azgaar subset the game actually reads** — cell geometry/navigation (`vertices`, `vertexIndices`, `neighbors`, `center`, `area`/`pop`/`biome`, `state`/`province`/`burg`), biome-name lookup, burg identity + feature flags + coords, province `fullName`. Slimmed `rivers`/`coords` retained per issue scope for future rendering.
2. **Provisioning baked in** (was re-rolled each play with a non-seeded `new Random()`): `isCityOfLight`, per-cell `challengeRating`, generated cell/burg locations, adjusted burg `population`/`size`.
3. **Reserved enrichment containers** — optional, empty-by-default `enrichment` blocks (NPCs, history, POIs, asset refs) with an `EnrichmentStatus` flag on every enrichable object, so Phase 1 can bake a valid world with no authored content.

## Key decisions

- **Kept `vertices`** (the issue suggested dropping them) — the polygon `NavigationScreen`/`WorldMapScreen` rendering reads `map.vertices` + `cell.v`, so dropping them would break rendering today.
- **Excluded per-playthrough progress** (`ExploredPercent`, `Discovered`, party/player) — the canonical world is immutable; progress stays in the save game.
- **Locations reference `LocationTypes` by `typeKey`** instead of embedding the full template, keeping the file slim.
- **`DolWorldSerializer`** is the shared `System.Text.Json` source of truth: camelCase, string enums, indented, null containers omitted → AI-friendly to author by hand or agent.
- **`schemaVersion`** on the root supports format evolution.

## Deliverables

- [x] `DolWorld` model(s) in `DolCon.Core`
- [x] `docs/WORLD_DOL_FORMAT.md` (schema, versioning strategy, kept-vs-dropped breakdown)
- [x] `schemaVersion` field on the root
- [x] System.Text.Json serialization with lossless round-trip

## Tests / verification

`DolCon.Core.Tests/World/DolWorldSerializationTests.cs`: full lossless round-trip (`serialize → deserialize → BeEquivalentTo`), minimal world omits null enrichment, human-readable enums + `schemaVersion` assertions, and `typeKey` catalog rehydration. **All 270 Core tests pass; full solution builds clean (0 warnings).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)