### PR TITLE
Phase 1 — WorldForge skeleton + passthrough bake (#74)

### DIFF
--- a/DolCon.Core.Tests/MapServiceTests.cs
+++ b/DolCon.Core.Tests/MapServiceTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace DolCon.Core.Tests;
 
-using System.Drawing;
 using Enums;
 using FluentAssertions;
-using Models.BaseTypes;
 using Services;
 
 public class MapServiceTests
@@ -29,61 +27,5 @@ public class MapServiceTests
     {
         var actual = MapService.GetDirection(x1, y1, x2, y2);
         actual.Should().Be(expected);
-    }
-
-    [Theory]
-    [InlineData(1, BurgSize.Town, 2.4)]
-    [InlineData(100, BurgSize.Megalopolis, 450)]
-    [InlineData(.5, BurgSize.Village, .1)]
-    [InlineData(71, BurgSize.Megalopolis, 331.2)]
-    [InlineData(3.5, BurgSize.Town, 14.18)]
-    [InlineData(7.6, BurgSize.Town, 33.44)]
-    public void GivenABurgWithAPopulationThenExpectSizeAndPopulationToBeAdjusted(double burgPop, BurgSize size,
-        double near)
-    {
-        var burg = new Burg()
-        {
-            population = burgPop,
-            isCityOfLight = false,
-        };
-
-        MapService.AdjustBurgSize(burg, .5);
-
-        burg.size.Should().Be(size);
-        burg.population.Should().BeApproximately(near, .1);
-    }
-
-    [Fact]
-    public void GivenACellCalculateTheChallengeRating()
-    {
-        // Arrange
-        var cell = new Cell
-        {
-            p = new List<double>
-            {
-                50, 50
-            }
-        };
-        // Act
-        var actual = MapService.CalculateChallengeRating(cell, 25,25, 50);
-        // Assert
-        actual.Should().Be(14.125);
-    }
-    
-    [Fact]
-    public void GivenACellMoreThanCrDistanceCalculateTheChallengeRating()
-    {
-        // Arrange
-        var cell = new Cell
-        {
-            p = new List<double>
-            {
-                75, 75
-            }
-        };
-        // Act
-        var actual = MapService.CalculateChallengeRating(cell, 25,25, 50);
-        // Assert
-        actual.Should().Be(28.25);
     }
 }

--- a/DolCon.Core.Tests/World/WorldBakerTests.cs
+++ b/DolCon.Core.Tests/World/WorldBakerTests.cs
@@ -1,0 +1,142 @@
+namespace DolCon.Core.Tests.World;
+
+using DolCon.Core.Models.BaseTypes;
+using DolCon.Core.Models.World;
+using DolCon.Core.Services;
+using FluentAssertions;
+
+public class WorldBakerTests
+{
+    private const int CellCount = 6;
+    private const string CityOfLightName = "Lumengarde";
+
+    /// <summary>
+    /// A small, valid Azgaar-shaped map. A fresh instance per call because provisioning mutates it
+    /// in place (flags City of Light, adds locations, sets sizes).
+    /// </summary>
+    private static Map BuildFixtureMap()
+    {
+        var cells = new List<Cell>();
+        for (var i = 0; i < CellCount; i++)
+        {
+            cells.Add(new Cell
+            {
+                i = i,
+                v = new List<int> { i, i + 1, i + 2 },
+                c = new List<int> { (i + 1) % CellCount },
+                p = new List<double> { 10 + i * 20, 10 + i * 15 },
+                area = i % 2 == 0 ? 50 : 150,   // mix of small/large CellSize
+                pop = i * 0.05m,                 // mix of wild/rural/urban PopDensity
+                biome = i % 3,
+                state = 1,
+                province = 1,
+                burg = 0
+            });
+        }
+
+        var burgs = new List<Burg>
+        {
+            new() { i = 1, cell = 0, name = "Westford", population = 5, port = 1, x = 10, y = 10 },
+            new() { i = 2, cell = 2, name = "Eastvale", population = 40, temple = 1, citadel = 1, x = 50, y = 40 },
+            new() { i = 3, cell = 4, name = CityOfLightName, population = 200, port = 1, temple = 1, x = 90, y = 70 }
+        };
+
+        return new Map
+        {
+            info = new Info { mapName = "Fixtureland", seed = "987654", version = "1.99" },
+            coords = new Coords { latT = 90, latN = 60, latS = 20, lonT = 180, lonW = -40, lonE = 40 },
+            vertices = new List<MapVertex>
+            {
+                new() { p = new List<double> { 0, 0 }, v = new List<int>(), c = new List<int>() },
+                new() { p = new List<double> { 10, 0 }, v = new List<int>(), c = new List<int>() }
+            },
+            biomes = new Biomes { name = new List<string> { "Marine", "Hot desert", "Temperate deciduous forest" } },
+            Collections = new MapCollections
+            {
+                cells = cells,
+                burgs = burgs,
+                states = new List<State> { new() { i = 1, name = "Aurelia", fullName = "Kingdom of Aurelia" } },
+                provinces = new List<Province> { new() { i = 1, name = "Dawnmoor", fullName = "Province of Dawnmoor" } },
+                rivers = new List<River> { new() { i = 1, name = "Silverflow", cells = new List<int> { 0, 1 }, width = 2.5, length = 40, source = 0, mouth = 1 } },
+                cultures = new List<Culture>()
+            }
+        };
+    }
+
+    [Fact]
+    public void Bake_ProducesExpectedCountsAndStableCityOfLight()
+    {
+        var baker = new WorldBaker();
+
+        var world = baker.Bake(BuildFixtureMap(), seed: 42, new NoOpMapProvisioningCallback());
+
+        world.SchemaVersion.Should().Be(1);
+        world.Info.Name.Should().Be("Fixtureland");
+        world.Info.ProvisioningSeed.Should().Be(42);
+        world.Cells.Should().HaveCount(CellCount);
+        world.Burgs.Should().HaveCount(3);
+        world.Biomes.Should().HaveCount(3);
+        world.Rivers.Should().HaveCount(1);
+
+        world.Burgs.Should().ContainSingle(b => b.IsCityOfLight)
+            .Which.Name.Should().Be(CityOfLightName);
+
+        var locationsPlaced = world.Cells.Sum(c => c.Locations.Count) + world.Burgs.Sum(b => b.Locations.Count);
+        locationsPlaced.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void Bake_StoresProvisioningOntoTheWorld()
+    {
+        var baker = new WorldBaker();
+
+        var world = baker.Bake(BuildFixtureMap(), seed: 42, new NoOpMapProvisioningCallback());
+
+        // City of Light cell sits at distance 0 -> CR 0; every cell gets a CR and locations.
+        world.Cells.Should().OnlyContain(c => c.Locations.Count > 0);
+        var cityOfLight = world.Burgs.Single(b => b.IsCityOfLight);
+        cityOfLight.Size.Should().NotBe(default);
+        cityOfLight.Locations.Should().NotBeEmpty();
+
+        // Every baked location references a catalog type by key.
+        world.Burgs.SelectMany(b => b.Locations).Should().OnlyContain(l => !string.IsNullOrEmpty(l.TypeKey));
+    }
+
+    [Fact]
+    public void Bake_IsDeterministicForTheSameSeed()
+    {
+        var baker = new WorldBaker();
+
+        var first = baker.Bake(BuildFixtureMap(), seed: 12345, new NoOpMapProvisioningCallback());
+        var second = baker.Bake(BuildFixtureMap(), seed: 12345, new NoOpMapProvisioningCallback());
+
+        // GeneratedAt is wall-clock provenance, not content; everything else must match exactly.
+        second.Should().BeEquivalentTo(first, options => options.Excluding(w => w.Info.GeneratedAt));
+    }
+
+    [Fact]
+    public void Bake_DiffersForDifferentSeeds()
+    {
+        var baker = new WorldBaker();
+
+        var first = baker.Bake(BuildFixtureMap(), seed: 1, new NoOpMapProvisioningCallback());
+        var second = baker.Bake(BuildFixtureMap(), seed: 2, new NoOpMapProvisioningCallback());
+
+        // Different seeds should produce different placement (location ids always differ).
+        var firstIds = first.Burgs.SelectMany(b => b.Locations).Select(l => l.Id);
+        var secondIds = second.Burgs.SelectMany(b => b.Locations).Select(l => l.Id);
+        firstIds.Should().NotIntersectWith(secondIds);
+    }
+
+    [Fact]
+    public void Bake_RoundTripsThroughDolWorldSerializer()
+    {
+        var baker = new WorldBaker();
+        var world = baker.Bake(BuildFixtureMap(), seed: 7, new NoOpMapProvisioningCallback());
+
+        var json = DolWorldSerializer.Serialize(world);
+        var restored = DolWorldSerializer.Deserialize(json);
+
+        restored.Should().BeEquivalentTo(world);
+    }
+}

--- a/DolCon.Core.Tests/World/WorldProvisioningServiceTests.cs
+++ b/DolCon.Core.Tests/World/WorldProvisioningServiceTests.cs
@@ -1,0 +1,46 @@
+namespace DolCon.Core.Tests.World;
+
+using DolCon.Core.Enums;
+using DolCon.Core.Models.BaseTypes;
+using DolCon.Core.Services;
+using FluentAssertions;
+
+public class WorldProvisioningServiceTests
+{
+    [Theory]
+    [InlineData(1, BurgSize.Town, 2.4)]
+    [InlineData(100, BurgSize.Megalopolis, 450)]
+    [InlineData(.5, BurgSize.Village, .1)]
+    [InlineData(71, BurgSize.Megalopolis, 331.2)]
+    [InlineData(3.5, BurgSize.Town, 14.18)]
+    [InlineData(7.6, BurgSize.Town, 33.44)]
+    public void AdjustBurgSize_AdjustsSizeAndPopulation(double burgPop, BurgSize size, double near)
+    {
+        var burg = new Burg { population = burgPop, isCityOfLight = false };
+
+        WorldProvisioningService.AdjustBurgSize(burg, .5);
+
+        burg.size.Should().Be(size);
+        burg.population.Should().BeApproximately(near, .1);
+    }
+
+    [Fact]
+    public void CalculateChallengeRating_ScalesWithDistance()
+    {
+        var cell = new Cell { p = new List<double> { 50, 50 } };
+
+        var actual = WorldProvisioningService.CalculateChallengeRating(cell, 25, 25, 50);
+
+        actual.Should().Be(14.125);
+    }
+
+    [Fact]
+    public void CalculateChallengeRating_BeyondCrDistance_KeepsScaling()
+    {
+        var cell = new Cell { p = new List<double> { 75, 75 } };
+
+        var actual = WorldProvisioningService.CalculateChallengeRating(cell, 25, 25, 50);
+
+        actual.Should().Be(28.25);
+    }
+}

--- a/DolCon.Core/Models/World/DolWorld.cs
+++ b/DolCon.Core/Models/World/DolWorld.cs
@@ -40,6 +40,12 @@ public class WorldInfo
     public string? SourceAzgaarVersion { get; set; }
     public DateTime GeneratedAt { get; set; }
     public string? GeneratorVersion { get; set; }
+
+    /// <summary>
+    /// Seed used by the deterministic provisioner for this bake. Stored so a world is reproducible:
+    /// re-baking the same Azgaar export with this seed yields identical content.
+    /// </summary>
+    public int ProvisioningSeed { get; set; }
 }
 
 /// <summary>Geographic bounds carried over from the Azgaar export (reserved for future rendering).</summary>

--- a/DolCon.Core/Services/MapService.cs
+++ b/DolCon.Core/Services/MapService.cs
@@ -29,13 +29,14 @@ public class MapService : IMapService
     private readonly string _mapsPath;
     private readonly IPlayerService _playerService;
     private readonly IPositionUpdateHandler _positionUpdateHandler;
-    private static List<LocationType> _burgTypes = new();
-    private List<LocationType> _cellTypes = new();
+    private readonly IWorldProvisioningService _worldProvisioningService;
 
-    public MapService(IPlayerService playerService, IPositionUpdateHandler positionUpdateHandler)
+    public MapService(IPlayerService playerService, IPositionUpdateHandler positionUpdateHandler,
+        IWorldProvisioningService worldProvisioningService)
     {
         _playerService = playerService;
         _positionUpdateHandler = positionUpdateHandler;
+        _worldProvisioningService = worldProvisioningService;
         var mainPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "DolCon");
         _mapsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "DolCon",
             "Maps");
@@ -51,7 +52,8 @@ public class MapService : IMapService
         }
     }
 
-    public MapService(IPlayerService playerService) : this(playerService, new NoOpPositionUpdateHandler())
+    public MapService(IPlayerService playerService)
+        : this(playerService, new NoOpPositionUpdateHandler(), new WorldProvisioningService())
     {
     }
 
@@ -92,50 +94,14 @@ public class MapService : IMapService
     private void ProvisionMap(IMapProvisioningCallback callback, Map map,
         string? playerName = null, PlayerAbilities? abilities = null)
     {
-        callback.OnStatus("Identifying City of Light...");
-
-        var topPop = map.Collections.burgs.Max(x => x.population);
-        var cityOfLight = map.Collections.burgs.First(x => Math.Abs(x.population - topPop) < 0.01);
-        cityOfLight.isCityOfLight = true;
-
-        var dolLocations = LocationTypes.Types.Where(x => x.NeedsCityOfLight).ToList();
-        cityOfLight.locations.AddRange(dolLocations.Select(x => new Location
-            { Id = Guid.NewGuid(), Type = x, Name = x.Type, Rarity = x.Rarity }));
-        callback.OnEvent($"City of Light established as {cityOfLight.name}");
-
-        var colCell = map.Collections.cells.First(x => x.i == cityOfLight.cell);
-        var colX = colCell.p[0];
-        var colY = colCell.p[1];
-
-        callback.OnStatus("Provisioning cells...");
-
-        _cellTypes = LocationTypes.Types.Where(x => !x.IsBurgLocation).ToList();
-
-        var crDistance = map.Collections.cells.Max(x => x.p.Max()) / 2;
-
-        foreach (var cell in map.Collections.cells)
-        {
-            callback.OnStatus($"Setting up cell: {cell.i}...");
-            cell.locations.AddRange(ProvisionCellLocations(cell));
-            cell.ChallengeRating = CalculateChallengeRating(cell, colX, colY, crDistance);
-        }
-
-        callback.OnStatus("Provisioning burgs...");
-
-        var minPop = map.Collections.burgs.Min(x => x.population);
-
-        _burgTypes = LocationTypes.Types.Where(x => x is
-            { NeedsCityOfLight: false, IsBurgLocation: true, NeedsPort: false, NeedsTemple: false }).ToList();
-
-        foreach (var burg in map.Collections.burgs)
-        {
-            callback.OnStatus($"Setting up burg: {burg.name}...");
-            AdjustBurgSize(burg, minPop);
-            burg.locations.AddRange(ProvisionBurgLocations(burg));
-        }
+        // World provisioning now lives in WorldProvisioningService (shared with WorldForge). The game
+        // still provisions at load time until Phase 2 wires it to consume world.dol. A fresh seed each
+        // load preserves today's "flair differs every game" behaviour.
+        _worldProvisioningService.Provision(map, Environment.TickCount, callback);
 
         callback.OnStatus("Setting player position...");
 
+        var cityOfLight = map.Collections.burgs.First(x => x.isCityOfLight);
         SaveGameService.Party = new Party
         {
             Cell = cityOfLight.cell,
@@ -149,270 +115,6 @@ public class MapService : IMapService
         _positionUpdateHandler.OnPositionUpdated();
 
         callback.OnEvent($"Player position set to {cityOfLight.name}");
-    }
-
-    /// <summary>
-    /// Calculates the challenge rating for a cell based on its distance from the City of Light.
-    /// </summary>
-    /// <param name="cell">The cell to calculate the challenge rating for.</param>
-    /// <param name="colX">The X coordinate of the City of Light.</param>
-    /// <param name="colY">The Y coordinate of the City of Light.</param>
-    /// <param name="crDistance">The maximum distance used for CR scaling (typically map dimension).</param>
-    /// <returns>
-    /// A challenge rating value rounded to the nearest 1/8th (0.125).
-    /// Cells closer to the City of Light have lower CRs, while distant cells have higher CRs.
-    /// The rating scales from 0 to 20 based on the distance ratio.
-    /// </returns>
-    public static double CalculateChallengeRating(Cell cell, double colX, double colY, double crDistance)
-    {
-        var x = cell.p[0];
-        var y = cell.p[1];
-        var distance = Math.Sqrt(Math.Pow(x - colX, 2) + Math.Pow(y - colY, 2));
-        var crRatio = distance / crDistance;
-        var rawRating = crRatio * 20;
-        var nearest8th = Math.Round(rawRating * 8, MidpointRounding.AwayFromZero) / 8;
-        return nearest8th;
-    }
-
-    private IEnumerable<Location> ProvisionCellLocations(Cell cell)
-    {
-        var locations = new List<Location>();
-
-        var wilderness = _cellTypes.Where(x => x.isWild).ToList();
-        var nonWilderness = _cellTypes.Where(x => !x.isWild).ToList();
-
-        int wildCells;
-        int nonWildCells;
-
-        switch (cell)
-        {
-            case { CellSize: CellSize.small, PopDensity: PopDensity.wild }:
-
-                nonWildCells = 1;
-                wildCells = 4;
-                break;
-            case { CellSize: CellSize.small, PopDensity: PopDensity.rural }:
-                nonWildCells = 2;
-                wildCells = 3;
-                break;
-            case { CellSize: CellSize.small, PopDensity: PopDensity.urban }:
-                nonWildCells = 3;
-                wildCells = 2;
-                break;
-            case { CellSize: CellSize.large, PopDensity: PopDensity.wild }:
-                nonWildCells = 2;
-                wildCells = 6;
-                break;
-            case { CellSize: CellSize.large, PopDensity: PopDensity.rural }:
-                nonWildCells = 3;
-                wildCells = 5;
-                break;
-            case { CellSize: CellSize.large, PopDensity: PopDensity.urban }:
-                nonWildCells = 5;
-                wildCells = 3;
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
-
-        var random = new Random();
-        var i = 0;
-        while (i < nonWildCells)
-        {
-            var index = random.Next(nonWilderness.Count);
-            var location = nonWilderness[index];
-            if (!location.AllowMultiple && locations.Any(x => x.Type == location))
-            {
-                continue;
-            }
-
-            locations.Add(new Location { Id = Guid.NewGuid(), Type = location, Name = location.Type, Rarity = location.Rarity });
-            i++;
-        }
-
-        i = 0;
-        while (i < wildCells)
-        {
-            var index = random.Next(wilderness.Count);
-            var location = wilderness[index];
-            if (!location.AllowMultiple && locations.Any(x => x.Type == location))
-            {
-                continue;
-            }
-
-            locations.Add(new Location { Id = Guid.NewGuid(), Type = location, Name = location.Type, Rarity = location.Rarity });
-            i++;
-        }
-
-        return locations;
-    }
-
-    public static void AdjustBurgSize(Burg burg, double minPop)
-    {
-        double maxPop = 75;
-        double idealMin = .1;
-        double idealMax = 350;
-
-        if (burg.population < maxPop)
-        {
-            burg.population = (((burg.population - minPop) / (maxPop - minPop)) * (idealMax - idealMin)) + idealMin;
-
-            burg.population = burg.isCityOfLight ? burg.population * 3 : burg.population;
-        }
-        else
-        {
-            burg.population += idealMax;
-        }
-
-        burg.size = burg.population switch
-        {
-            > 0 and < 2 => BurgSize.Village,
-            >= 2 and < 50 => BurgSize.Town,
-            >= 50 and < 150 => BurgSize.City,
-            >= 150 and < 300 => BurgSize.Metropolis,
-            >= 300 => BurgSize.Megalopolis,
-            _ => burg.size
-        };
-    }
-
-    private static List<Location> ProvisionBurgLocations(Burg burg)
-    {
-        var locations = new List<Location>();
-
-        var sequence = burg.size switch
-        {
-            BurgSize.Village => new[] { 2, 1, 0, 0, 0 },
-            BurgSize.Town => new[] { 3, 2, 1, 0, 0 },
-            BurgSize.City => new[] { 5, 3, 2, 1, 0 },
-            BurgSize.Metropolis => new[] { 8, 5, 3, 2, 1 },
-            BurgSize.Megalopolis => new[] { 13, 8, 5, 3, 2 },
-            _ => new[] { 0, 0, 0, 0, 0 }
-        };
-
-        if (burg.port == 1)
-        {
-            switch (burg.size)
-            {
-                case BurgSize.Village:
-                    var pier = LocationTypes.Types.First(x => x.Type == "pier");
-                    locations.Add(new Location { Id = Guid.NewGuid(), Type = pier, Name = "Pier", Rarity = pier.Rarity });
-                    break;
-                case BurgSize.Town:
-                    var dock = LocationTypes.Types.First(x => x.Type == "dock");
-                    locations.Add(new Location { Id = Guid.NewGuid(), Type = dock, Name = $"{burg.name} Docks", Rarity = dock.Rarity });
-                    break;
-                case BurgSize.City:
-                    var harbor = LocationTypes.Types.First(x => x.Type == "harbor");
-                    locations.Add(new Location { Id = Guid.NewGuid(), Type = harbor, Name = $"{burg.name} Harbor", Rarity = harbor.Rarity });
-                    break;
-                case BurgSize.Metropolis:
-                case BurgSize.Megalopolis:
-                    var port = LocationTypes.Types.First(x => x.Type == "port");
-                    locations.Add(new Location { Id = Guid.NewGuid(), Type = port, Name = $"{burg.name} Port", Rarity = port.Rarity });
-                    break;
-            }
-        }
-
-        if (burg is { temple: 1, isCityOfLight: false })
-        {
-            switch (burg.size)
-            {
-                case BurgSize.Village:
-                case BurgSize.Town:
-                    var shrine = LocationTypes.Types.First(x => x.Type == "shrine");
-                    locations.Add(new Location { Id = Guid.NewGuid(), Type = shrine, Name = $"{burg.name} Shrine", Rarity = shrine.Rarity });
-                    break;
-                case BurgSize.City:
-                case BurgSize.Metropolis:
-                    var temple = LocationTypes.Types.First(x => x.Type == "temple");
-                    locations.Add(new Location { Id = Guid.NewGuid(), Type = temple, Name = $"{burg.name} Temple", Rarity = temple.Rarity });
-                    break;
-                case BurgSize.Megalopolis:
-                    var basilica = LocationTypes.Types.First(x => x.Type == "basilica");
-                    locations.Add(new Location
-                        { Id = Guid.NewGuid(), Type = basilica, Name = $"{burg.name} Basilica", Rarity = basilica.Rarity });
-                    break;
-            }
-        }
-
-        if (burg is { citadel: 1, isCityOfLight: false })
-        {
-            switch (burg.size)
-            {
-                case BurgSize.Village:
-                case BurgSize.Town:
-                    var manor = LocationTypes.Types.First(x => x.Type == "manor");
-                    locations.Add(new Location { Id = Guid.NewGuid(), Type = manor, Name = $"{burg.name} Manor", Rarity = manor.Rarity });
-                    break;
-                case BurgSize.City:
-                    var castle = LocationTypes.Types.First(x => x.Type == "castle");
-                    locations.Add(new Location { Id = Guid.NewGuid(), Type = castle, Name = $"{burg.name} Castle", Rarity = castle.Rarity });
-                    break;
-                case BurgSize.Metropolis:
-                    var fortress = LocationTypes.Types.First(x => x.Type == "fortress");
-                    locations.Add(new Location
-                        { Id = Guid.NewGuid(), Type = fortress, Name = $"{burg.name} Fortress", Rarity = fortress.Rarity });
-                    break;
-                case BurgSize.Megalopolis:
-                    var citadel = LocationTypes.Types.First(x => x.Type == "citadel");
-                    locations.Add(new Location
-                        { Id = Guid.NewGuid(), Type = citadel, Name = $"{burg.name} Citadel", Rarity = citadel.Rarity });
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        var cnt = _burgTypes.Count - 1;
-        for (var i = 0; i < 4; i++)
-        {
-            var j = 0;
-            while (j < sequence[i])
-            {
-                var rarity = (Rarity)i;
-                var rnd = new Random().Next(0, cnt);
-                var locationType = _burgTypes[rnd];
-                if (rarity < locationType.Rarity || rarity > locationType.MaxRarity)
-                {
-                    j++;
-                    continue;
-                }
-
-                if (locationType.AllowMultiple == false && locations.Any(x => x.Type.Type == locationType.Type))
-                {
-                    j++;
-                    continue;
-                }
-
-                if ((locationType.NeedsCitadel && burg.citadel != 1) ||
-                    (locationType.NeedsPlaza && burg.plaza != 1) ||
-                    (locationType.NeedsShanty && burg.shanty != 1) ||
-                    (locationType.NeedsWalls && burg.walls != 1) ||
-                    (locationType.NeedsTemple && burg.temple != 1))
-                {
-                    j++;
-                    continue;
-                }
-
-                var location = new Location
-                {
-                    Id = Guid.NewGuid(),
-                    Type = locationType,
-                    Name = $"{burg.name} {locationType.Type}",
-                    Rarity = rarity
-                };
-                locations.Add(location);
-                j++;
-            }
-        }
-
-        if (locations.Count == 0)
-        {
-            var tavern = LocationTypes.Types.First(x => x.Type == "tavern");
-            locations.Add(new Location { Id = Guid.NewGuid(), Type = tavern, Name = $"{burg.name} Tavern", Rarity = tavern.Rarity });
-        }
-
-        return locations;
     }
 
     private static async Task<Map?> DeserializeMap(FileSystemInfo mapFile)

--- a/DolCon.Core/Services/WorldBaker.cs
+++ b/DolCon.Core/Services/WorldBaker.cs
@@ -1,0 +1,146 @@
+namespace DolCon.Core.Services;
+
+using System.Reflection;
+using DolCon.Core.Models;
+using DolCon.Core.Models.BaseTypes;
+using DolCon.Core.Models.World;
+
+public interface IWorldBaker
+{
+    /// <summary>
+    /// Provisions a deserialized Azgaar map (deterministically, given <paramref name="seed"/>) and
+    /// maps it into a canonical <see cref="DolWorld"/>, dropping the Azgaar bulk the game never reads.
+    /// </summary>
+    DolWorld Bake(Map map, int seed, IMapProvisioningCallback callback);
+}
+
+/// <summary>
+/// Turns a raw Azgaar export into a baked <see cref="DolWorld"/>. This is the reusable bake step
+/// WorldForge drives; it lives in Core so it can be unit-tested and shares the provisioning logic.
+/// </summary>
+public class WorldBaker : IWorldBaker
+{
+    private readonly IWorldProvisioningService _provisioning;
+
+    public WorldBaker(IWorldProvisioningService provisioning)
+    {
+        _provisioning = provisioning;
+    }
+
+    public WorldBaker() : this(new WorldProvisioningService())
+    {
+    }
+
+    public DolWorld Bake(Map map, int seed, IMapProvisioningCallback callback)
+    {
+        _provisioning.Provision(map, seed, callback);
+
+        callback.OnStatus("Mapping to world.dol...");
+        var world = ToDolWorld(map, seed);
+
+        var cityOfLight = map.Collections.burgs.FirstOrDefault(b => b.isCityOfLight)?.name ?? "(none)";
+        var locationCount = world.Cells.Sum(c => c.Locations.Count) + world.Burgs.Sum(b => b.Locations.Count);
+        callback.OnEvent(
+            $"Baked '{world.Info.Name}': {world.Cells.Count} cells, {world.Burgs.Count} burgs, " +
+            $"City of Light = {cityOfLight}, {locationCount} locations placed");
+
+        return world;
+    }
+
+    private static DolWorld ToDolWorld(Map map, int seed)
+    {
+        return new DolWorld
+        {
+            SchemaVersion = 1,
+            Info = new WorldInfo
+            {
+                Name = map.info?.mapName ?? "Unnamed World",
+                SourceSeed = map.info?.seed,
+                SourceAzgaarVersion = map.info?.version,
+                GeneratedAt = DateTime.UtcNow,
+                GeneratorVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString(),
+                ProvisioningSeed = seed
+            },
+            Coords = ToCoords(map.coords),
+            Vertices = map.vertices.Select(v => new WorldVertex { P = v.p.ToArray() }).ToList(),
+            Biomes = map.biomes?.name?.ToList() ?? new List<string>(),
+            Cells = map.Collections.cells.Select(ToCell).ToList(),
+            Burgs = map.Collections.burgs.Select(ToBurg).ToList(),
+            States = map.Collections.states.Select(ToState).ToList(),
+            Provinces = map.Collections.provinces.Select(ToProvince).ToList(),
+            Rivers = map.Collections.rivers?.Select(ToRiver).ToList() ?? new List<WorldRiver>()
+        };
+    }
+
+    private static WorldCoords ToCoords(Coords c) => c is null
+        ? new WorldCoords()
+        : new WorldCoords { LatT = c.latT, LatN = c.latN, LatS = c.latS, LonT = c.lonT, LonW = c.lonW, LonE = c.lonE };
+
+    private static WorldCell ToCell(Cell cell) => new()
+    {
+        Id = cell.i,
+        VertexIndices = cell.v ?? new List<int>(),
+        Neighbors = cell.c ?? new List<int>(),
+        Center = cell.p?.ToArray() ?? Array.Empty<double>(),
+        Area = cell.area,
+        Pop = cell.pop,
+        Biome = cell.biome,
+        State = cell.state,
+        Province = cell.province,
+        Burg = cell.burg,
+        ChallengeRating = cell.ChallengeRating,
+        Locations = cell.locations.Select(ToLocation).ToList()
+    };
+
+    private static WorldBurg ToBurg(Burg burg) => new()
+    {
+        Id = burg.i ?? 0,
+        Name = burg.name,
+        Cell = burg.cell,
+        Population = burg.population,
+        Size = burg.size,
+        IsCityOfLight = burg.isCityOfLight,
+        X = burg.x,
+        Y = burg.y,
+        HasPort = burg.port == 1,
+        HasCitadel = burg.citadel == 1,
+        HasPlaza = burg.plaza == 1,
+        HasWalls = burg.walls == 1,
+        HasShanty = burg.shanty == 1,
+        HasTemple = burg.temple == 1,
+        Locations = burg.locations.Select(ToLocation).ToList()
+    };
+
+    private static WorldState ToState(State state) => new()
+    {
+        Id = state.i,
+        Name = state.name,
+        FullName = state.fullName
+    };
+
+    private static WorldProvince ToProvince(Province province) => new()
+    {
+        Id = province.i,
+        Name = province.name,
+        FullName = province.fullName
+    };
+
+    private static WorldRiver ToRiver(River river) => new()
+    {
+        Id = river.i,
+        Name = river.name,
+        Cells = river.cells ?? new List<int>(),
+        Width = river.width,
+        Length = river.length,
+        Source = river.source,
+        Mouth = river.mouth
+    };
+
+    private static WorldLocation ToLocation(Location location) => new()
+    {
+        Id = location.Id,
+        Name = location.Name,
+        TypeKey = location.Type.Type,
+        Rarity = location.Rarity
+    };
+}

--- a/DolCon.Core/Services/WorldProvisioningService.cs
+++ b/DolCon.Core/Services/WorldProvisioningService.cs
@@ -1,0 +1,310 @@
+namespace DolCon.Core.Services;
+
+using DolCon.Core.Enums;
+using DolCon.Core.Models;
+using DolCon.Core.Models.BaseTypes;
+
+public interface IWorldProvisioningService
+{
+    /// <summary>
+    /// Provisions a freshly-deserialized Azgaar map in place: flags the City of Light, computes
+    /// per-cell challenge ratings, adjusts burg sizes, and places cell/burg locations. Deterministic
+    /// for a given <paramref name="seed"/> — the same input + seed always produces the same result.
+    /// </summary>
+    void Provision(Map map, int seed, IMapProvisioningCallback callback);
+}
+
+/// <summary>
+/// The single home for world provisioning. Lifted out of <see cref="MapService"/> so both the game
+/// (which still loads raw Azgaar until Phase 2) and WorldForge (the baker) share one implementation.
+/// All randomness flows through one seeded <see cref="Random"/> so a bake is reproducible.
+/// </summary>
+public class WorldProvisioningService : IWorldProvisioningService
+{
+    public void Provision(Map map, int seed, IMapProvisioningCallback callback)
+    {
+        var rng = new Random(seed);
+
+        callback.OnStatus("Identifying City of Light...");
+
+        var topPop = map.Collections.burgs.Max(x => x.population);
+        var cityOfLight = map.Collections.burgs.First(x => Math.Abs(x.population - topPop) < 0.01);
+        cityOfLight.isCityOfLight = true;
+
+        foreach (var type in LocationTypes.Types.Where(x => x.NeedsCityOfLight))
+        {
+            cityOfLight.locations.Add(new Location
+                { Id = NewDeterministicGuid(rng), Type = type, Name = type.Type, Rarity = type.Rarity });
+        }
+
+        callback.OnEvent($"City of Light established as {cityOfLight.name}");
+
+        var colCell = map.Collections.cells.First(x => x.i == cityOfLight.cell);
+        var colX = colCell.p[0];
+        var colY = colCell.p[1];
+
+        callback.OnStatus("Provisioning cells...");
+
+        var cellTypes = LocationTypes.Types.Where(x => !x.IsBurgLocation).ToList();
+        var crDistance = map.Collections.cells.Max(x => x.p.Max()) / 2;
+
+        foreach (var cell in map.Collections.cells)
+        {
+            cell.locations.AddRange(ProvisionCellLocations(cell, cellTypes, rng));
+            cell.ChallengeRating = CalculateChallengeRating(cell, colX, colY, crDistance);
+        }
+
+        callback.OnStatus("Provisioning burgs...");
+
+        var minPop = map.Collections.burgs.Min(x => x.population);
+        var burgTypes = LocationTypes.Types.Where(x => x is
+            { NeedsCityOfLight: false, IsBurgLocation: true, NeedsPort: false, NeedsTemple: false }).ToList();
+
+        foreach (var burg in map.Collections.burgs)
+        {
+            AdjustBurgSize(burg, minPop);
+            burg.locations.AddRange(ProvisionBurgLocations(burg, burgTypes, rng));
+        }
+
+        callback.OnEvent("World provisioning complete");
+    }
+
+    /// <summary>
+    /// Calculates the challenge rating for a cell based on its distance from the City of Light.
+    /// Cells closer to the City of Light have lower CRs; the rating scales 0–20 by distance ratio
+    /// and is rounded to the nearest 1/8th (0.125).
+    /// </summary>
+    public static double CalculateChallengeRating(Cell cell, double colX, double colY, double crDistance)
+    {
+        var x = cell.p[0];
+        var y = cell.p[1];
+        var distance = Math.Sqrt(Math.Pow(x - colX, 2) + Math.Pow(y - colY, 2));
+        var crRatio = distance / crDistance;
+        var rawRating = crRatio * 20;
+        var nearest8th = Math.Round(rawRating * 8, MidpointRounding.AwayFromZero) / 8;
+        return nearest8th;
+    }
+
+    public static void AdjustBurgSize(Burg burg, double minPop)
+    {
+        double maxPop = 75;
+        double idealMin = .1;
+        double idealMax = 350;
+
+        if (burg.population < maxPop)
+        {
+            burg.population = (((burg.population - minPop) / (maxPop - minPop)) * (idealMax - idealMin)) + idealMin;
+
+            burg.population = burg.isCityOfLight ? burg.population * 3 : burg.population;
+        }
+        else
+        {
+            burg.population += idealMax;
+        }
+
+        burg.size = burg.population switch
+        {
+            > 0 and < 2 => BurgSize.Village,
+            >= 2 and < 50 => BurgSize.Town,
+            >= 50 and < 150 => BurgSize.City,
+            >= 150 and < 300 => BurgSize.Metropolis,
+            >= 300 => BurgSize.Megalopolis,
+            _ => burg.size
+        };
+    }
+
+    private static IEnumerable<Location> ProvisionCellLocations(Cell cell, List<LocationType> cellTypes, Random rng)
+    {
+        var locations = new List<Location>();
+
+        var wilderness = cellTypes.Where(x => x.isWild).ToList();
+        var nonWilderness = cellTypes.Where(x => !x.isWild).ToList();
+
+        var (nonWildCells, wildCells) = cell switch
+        {
+            { CellSize: CellSize.small, PopDensity: PopDensity.wild } => (1, 4),
+            { CellSize: CellSize.small, PopDensity: PopDensity.rural } => (2, 3),
+            { CellSize: CellSize.small, PopDensity: PopDensity.urban } => (3, 2),
+            { CellSize: CellSize.large, PopDensity: PopDensity.wild } => (2, 6),
+            { CellSize: CellSize.large, PopDensity: PopDensity.rural } => (3, 5),
+            { CellSize: CellSize.large, PopDensity: PopDensity.urban } => (5, 3),
+            _ => throw new ArgumentOutOfRangeException(nameof(cell))
+        };
+
+        var i = 0;
+        while (i < nonWildCells)
+        {
+            var location = nonWilderness[rng.Next(nonWilderness.Count)];
+            if (!location.AllowMultiple && locations.Any(x => x.Type == location))
+            {
+                continue;
+            }
+
+            locations.Add(new Location
+                { Id = NewDeterministicGuid(rng), Type = location, Name = location.Type, Rarity = location.Rarity });
+            i++;
+        }
+
+        i = 0;
+        while (i < wildCells)
+        {
+            var location = wilderness[rng.Next(wilderness.Count)];
+            if (!location.AllowMultiple && locations.Any(x => x.Type == location))
+            {
+                continue;
+            }
+
+            locations.Add(new Location
+                { Id = NewDeterministicGuid(rng), Type = location, Name = location.Type, Rarity = location.Rarity });
+            i++;
+        }
+
+        return locations;
+    }
+
+    private static List<Location> ProvisionBurgLocations(Burg burg, List<LocationType> burgTypes, Random rng)
+    {
+        var locations = new List<Location>();
+
+        var sequence = burg.size switch
+        {
+            BurgSize.Village => new[] { 2, 1, 0, 0, 0 },
+            BurgSize.Town => new[] { 3, 2, 1, 0, 0 },
+            BurgSize.City => new[] { 5, 3, 2, 1, 0 },
+            BurgSize.Metropolis => new[] { 8, 5, 3, 2, 1 },
+            BurgSize.Megalopolis => new[] { 13, 8, 5, 3, 2 },
+            _ => new[] { 0, 0, 0, 0, 0 }
+        };
+
+        if (burg.port == 1)
+        {
+            switch (burg.size)
+            {
+                case BurgSize.Village:
+                    var pier = LocationTypes.Types.First(x => x.Type == "pier");
+                    locations.Add(new Location { Id = NewDeterministicGuid(rng), Type = pier, Name = "Pier", Rarity = pier.Rarity });
+                    break;
+                case BurgSize.Town:
+                    var dock = LocationTypes.Types.First(x => x.Type == "dock");
+                    locations.Add(new Location { Id = NewDeterministicGuid(rng), Type = dock, Name = $"{burg.name} Docks", Rarity = dock.Rarity });
+                    break;
+                case BurgSize.City:
+                    var harbor = LocationTypes.Types.First(x => x.Type == "harbor");
+                    locations.Add(new Location { Id = NewDeterministicGuid(rng), Type = harbor, Name = $"{burg.name} Harbor", Rarity = harbor.Rarity });
+                    break;
+                case BurgSize.Metropolis:
+                case BurgSize.Megalopolis:
+                    var port = LocationTypes.Types.First(x => x.Type == "port");
+                    locations.Add(new Location { Id = NewDeterministicGuid(rng), Type = port, Name = $"{burg.name} Port", Rarity = port.Rarity });
+                    break;
+            }
+        }
+
+        if (burg is { temple: 1, isCityOfLight: false })
+        {
+            switch (burg.size)
+            {
+                case BurgSize.Village:
+                case BurgSize.Town:
+                    var shrine = LocationTypes.Types.First(x => x.Type == "shrine");
+                    locations.Add(new Location { Id = NewDeterministicGuid(rng), Type = shrine, Name = $"{burg.name} Shrine", Rarity = shrine.Rarity });
+                    break;
+                case BurgSize.City:
+                case BurgSize.Metropolis:
+                    var temple = LocationTypes.Types.First(x => x.Type == "temple");
+                    locations.Add(new Location { Id = NewDeterministicGuid(rng), Type = temple, Name = $"{burg.name} Temple", Rarity = temple.Rarity });
+                    break;
+                case BurgSize.Megalopolis:
+                    var basilica = LocationTypes.Types.First(x => x.Type == "basilica");
+                    locations.Add(new Location
+                        { Id = NewDeterministicGuid(rng), Type = basilica, Name = $"{burg.name} Basilica", Rarity = basilica.Rarity });
+                    break;
+            }
+        }
+
+        if (burg is { citadel: 1, isCityOfLight: false })
+        {
+            switch (burg.size)
+            {
+                case BurgSize.Village:
+                case BurgSize.Town:
+                    var manor = LocationTypes.Types.First(x => x.Type == "manor");
+                    locations.Add(new Location { Id = NewDeterministicGuid(rng), Type = manor, Name = $"{burg.name} Manor", Rarity = manor.Rarity });
+                    break;
+                case BurgSize.City:
+                    var castle = LocationTypes.Types.First(x => x.Type == "castle");
+                    locations.Add(new Location { Id = NewDeterministicGuid(rng), Type = castle, Name = $"{burg.name} Castle", Rarity = castle.Rarity });
+                    break;
+                case BurgSize.Metropolis:
+                    var fortress = LocationTypes.Types.First(x => x.Type == "fortress");
+                    locations.Add(new Location
+                        { Id = NewDeterministicGuid(rng), Type = fortress, Name = $"{burg.name} Fortress", Rarity = fortress.Rarity });
+                    break;
+                case BurgSize.Megalopolis:
+                    var citadel = LocationTypes.Types.First(x => x.Type == "citadel");
+                    locations.Add(new Location
+                        { Id = NewDeterministicGuid(rng), Type = citadel, Name = $"{burg.name} Citadel", Rarity = citadel.Rarity });
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(burg));
+            }
+        }
+
+        var cnt = burgTypes.Count - 1;
+        for (var i = 0; i < 4; i++)
+        {
+            var j = 0;
+            while (j < sequence[i])
+            {
+                var rarity = (Rarity)i;
+                var locationType = burgTypes[rng.Next(0, cnt)];
+                if (rarity < locationType.Rarity || rarity > locationType.MaxRarity)
+                {
+                    j++;
+                    continue;
+                }
+
+                if (locationType.AllowMultiple == false && locations.Any(x => x.Type.Type == locationType.Type))
+                {
+                    j++;
+                    continue;
+                }
+
+                if ((locationType.NeedsCitadel && burg.citadel != 1) ||
+                    (locationType.NeedsPlaza && burg.plaza != 1) ||
+                    (locationType.NeedsShanty && burg.shanty != 1) ||
+                    (locationType.NeedsWalls && burg.walls != 1) ||
+                    (locationType.NeedsTemple && burg.temple != 1))
+                {
+                    j++;
+                    continue;
+                }
+
+                locations.Add(new Location
+                {
+                    Id = NewDeterministicGuid(rng),
+                    Type = locationType,
+                    Name = $"{burg.name} {locationType.Type}",
+                    Rarity = rarity
+                });
+                j++;
+            }
+        }
+
+        if (locations.Count == 0)
+        {
+            var tavern = LocationTypes.Types.First(x => x.Type == "tavern");
+            locations.Add(new Location { Id = NewDeterministicGuid(rng), Type = tavern, Name = $"{burg.name} Tavern", Rarity = tavern.Rarity });
+        }
+
+        return locations;
+    }
+
+    /// <summary>Draws 16 bytes from the seeded RNG to build a reproducible GUID (replaces Guid.NewGuid()).</summary>
+    private static Guid NewDeterministicGuid(Random rng)
+    {
+        var bytes = new byte[16];
+        rng.NextBytes(bytes);
+        return new Guid(bytes);
+    }
+}

--- a/DolCon.MonoGame/Game1.cs
+++ b/DolCon.MonoGame/Game1.cs
@@ -67,7 +67,7 @@ public class Game1 : Game
         // Initialize core services
         _playerService = new PlayerService();
         var positionHandler = new NoOpPositionUpdateHandler();
-        _mapService = new MapService(_playerService, positionHandler);
+        _mapService = new MapService(_playerService, positionHandler, new WorldProvisioningService());
         _moveService = new MoveService(positionHandler);
 
         var itemsService = new ItemsService();

--- a/DolCon.WorldForge/ConsoleProvisioningCallback.cs
+++ b/DolCon.WorldForge/ConsoleProvisioningCallback.cs
@@ -1,0 +1,11 @@
+namespace DolCon.WorldForge;
+
+using DolCon.Core.Services;
+
+/// <summary>Streams bake progress to the console: transient status lines and persistent events.</summary>
+public sealed class ConsoleProvisioningCallback : IMapProvisioningCallback
+{
+    public void OnStatus(string message) => Console.WriteLine($"  … {message}");
+
+    public void OnEvent(string message) => Console.WriteLine($"  ✓ {message}");
+}

--- a/DolCon.WorldForge/DolCon.WorldForge.csproj
+++ b/DolCon.WorldForge/DolCon.WorldForge.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>worldforge</AssemblyName>
+    <RootNamespace>DolCon.WorldForge</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DolCon.Core\DolCon.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DolCon.WorldForge/Program.cs
+++ b/DolCon.WorldForge/Program.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using DolCon.Core.Models.BaseTypes;
+using DolCon.Core.Models.World;
+using DolCon.Core.Services;
+using DolCon.WorldForge;
+
+return WorldForgeCli.Run(args);
+
+internal static class WorldForgeCli
+{
+    public static int Run(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            PrintUsage();
+            return 1;
+        }
+
+        return args[0] switch
+        {
+            "bake" => Bake(args[1..]),
+            "-h" or "--help" or "help" => PrintUsage(),
+            _ => Fail($"Unknown command '{args[0]}'.")
+        };
+    }
+
+    private static int Bake(string[] args)
+    {
+        string? input = null;
+        string? output = null;
+        int? seed = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "-o" or "--output":
+                    if (++i >= args.Length) return Fail("Missing value for -o/--output.");
+                    output = args[i];
+                    break;
+                case "--seed":
+                    if (++i >= args.Length) return Fail("Missing value for --seed.");
+                    if (!int.TryParse(args[i], out var parsedSeed)) return Fail($"--seed must be an integer, got '{args[i]}'.");
+                    seed = parsedSeed;
+                    break;
+                default:
+                    if (input is null) input = args[i];
+                    else return Fail($"Unexpected argument '{args[i]}'.");
+                    break;
+            }
+        }
+
+        if (input is null) return Fail("Missing <azgaar-export.json> input path.");
+        if (output is null) return Fail("Missing -o <world.dol> output path.");
+        if (!File.Exists(input)) return Fail($"Input file not found: {input}");
+
+        Console.WriteLine($"WorldForge: baking '{input}'");
+
+        Map? map;
+        try
+        {
+            using var stream = File.OpenRead(input);
+            map = JsonSerializer.Deserialize<Map>(stream);
+        }
+        catch (JsonException ex)
+        {
+            return Fail($"Failed to parse Azgaar export: {ex.Message}");
+        }
+
+        if (map?.Collections?.cells is null || map.Collections.burgs is null)
+        {
+            return Fail("Azgaar export is missing required cells/burgs collections.");
+        }
+
+        var resolvedSeed = seed ?? DefaultSeed(map);
+        Console.WriteLine($"  seed: {resolvedSeed}{(seed is null ? " (derived from map)" : "")}");
+
+        var baker = new WorldBaker();
+        var world = baker.Bake(map, resolvedSeed, new ConsoleProvisioningCallback());
+
+        var json = DolWorldSerializer.Serialize(world);
+        var outputDir = Path.GetDirectoryName(Path.GetFullPath(output));
+        if (!string.IsNullOrEmpty(outputDir)) Directory.CreateDirectory(outputDir);
+        File.WriteAllText(output, json);
+
+        PrintSummary(world, output);
+        return 0;
+    }
+
+    private static void PrintSummary(DolWorld world, string output)
+    {
+        var cityOfLight = world.Burgs.FirstOrDefault(b => b.IsCityOfLight)?.Name ?? "(none)";
+        var locations = world.Cells.Sum(c => c.Locations.Count) + world.Burgs.Sum(b => b.Locations.Count);
+        var bytes = new FileInfo(output).Length;
+
+        Console.WriteLine();
+        Console.WriteLine("Bake complete:");
+        Console.WriteLine($"  world         : {world.Info.Name}");
+        Console.WriteLine($"  schemaVersion : {world.SchemaVersion}");
+        Console.WriteLine($"  seed          : {world.Info.ProvisioningSeed}");
+        Console.WriteLine($"  cells         : {world.Cells.Count}");
+        Console.WriteLine($"  burgs         : {world.Burgs.Count}");
+        Console.WriteLine($"  City of Light : {cityOfLight}");
+        Console.WriteLine($"  locations     : {locations}");
+        Console.WriteLine($"  output        : {output} ({bytes:N0} bytes)");
+    }
+
+    /// <summary>
+    /// Default provisioning seed when none is supplied: the numeric Azgaar seed if parseable, else a
+    /// stable hash of it. This keeps a no-flag bake of the same export reproducible.
+    /// </summary>
+    private static int DefaultSeed(Map map)
+    {
+        var azgaarSeed = map.info?.seed;
+        if (string.IsNullOrEmpty(azgaarSeed)) return 0;
+        return int.TryParse(azgaarSeed, out var numeric) ? numeric : StableHash(azgaarSeed);
+    }
+
+    /// <summary>FNV-1a 32-bit hash — stable across runs/platforms (unlike string.GetHashCode()).</summary>
+    private static int StableHash(string value)
+    {
+        unchecked
+        {
+            var hash = (uint)2166136261;
+            foreach (var c in value)
+            {
+                hash ^= c;
+                hash *= 16777619;
+            }
+
+            return (int)hash;
+        }
+    }
+
+    private static int PrintUsage()
+    {
+        Console.WriteLine("""
+            WorldForge — bake an Azgaar export into a canonical world.dol
+
+            Usage:
+              worldforge bake <azgaar-export.json> -o <world.dol> [--seed <int>]
+
+            Options:
+              -o, --output   Path to write the baked world.dol (required).
+              --seed         Provisioning seed for reproducible bakes (default: derived from the map).
+              -h, --help     Show this help.
+            """);
+        return 0;
+    }
+
+    private static int Fail(string message)
+    {
+        Console.Error.WriteLine($"error: {message}");
+        return 1;
+    }
+}

--- a/dol-con-v2.sln
+++ b/dol-con-v2.sln
@@ -9,26 +9,68 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DolCon.Core.Tests", "DolCon
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DolCon.MonoGame", "DolCon.MonoGame\DolCon.MonoGame.csproj", "{4462E778-3D00-4122-9B5F-74FBD8422395}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DolCon.WorldForge", "DolCon.WorldForge\DolCon.WorldForge.csproj", "{FA4B0E62-985B-4D07-83D0-5918FAE5735B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2C9F2691-C960-4082-8294-810BCDF60B32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2C9F2691-C960-4082-8294-810BCDF60B32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C9F2691-C960-4082-8294-810BCDF60B32}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C9F2691-C960-4082-8294-810BCDF60B32}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C9F2691-C960-4082-8294-810BCDF60B32}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C9F2691-C960-4082-8294-810BCDF60B32}.Debug|x86.Build.0 = Debug|Any CPU
 		{2C9F2691-C960-4082-8294-810BCDF60B32}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C9F2691-C960-4082-8294-810BCDF60B32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C9F2691-C960-4082-8294-810BCDF60B32}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C9F2691-C960-4082-8294-810BCDF60B32}.Release|x64.Build.0 = Release|Any CPU
+		{2C9F2691-C960-4082-8294-810BCDF60B32}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C9F2691-C960-4082-8294-810BCDF60B32}.Release|x86.Build.0 = Release|Any CPU
 		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Debug|x64.Build.0 = Debug|Any CPU
+		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Debug|x86.Build.0 = Debug|Any CPU
 		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Release|x64.ActiveCfg = Release|Any CPU
+		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Release|x64.Build.0 = Release|Any CPU
+		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Release|x86.ActiveCfg = Release|Any CPU
+		{F09BA0E6-FB33-4AD5-83E1-257084E16864}.Release|x86.Build.0 = Release|Any CPU
 		{4462E778-3D00-4122-9B5F-74FBD8422395}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4462E778-3D00-4122-9B5F-74FBD8422395}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4462E778-3D00-4122-9B5F-74FBD8422395}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4462E778-3D00-4122-9B5F-74FBD8422395}.Debug|x64.Build.0 = Debug|Any CPU
+		{4462E778-3D00-4122-9B5F-74FBD8422395}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4462E778-3D00-4122-9B5F-74FBD8422395}.Debug|x86.Build.0 = Debug|Any CPU
 		{4462E778-3D00-4122-9B5F-74FBD8422395}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4462E778-3D00-4122-9B5F-74FBD8422395}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4462E778-3D00-4122-9B5F-74FBD8422395}.Release|x64.ActiveCfg = Release|Any CPU
+		{4462E778-3D00-4122-9B5F-74FBD8422395}.Release|x64.Build.0 = Release|Any CPU
+		{4462E778-3D00-4122-9B5F-74FBD8422395}.Release|x86.ActiveCfg = Release|Any CPU
+		{4462E778-3D00-4122-9B5F-74FBD8422395}.Release|x86.Build.0 = Release|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Debug|x64.Build.0 = Debug|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Debug|x86.Build.0 = Debug|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Release|x64.ActiveCfg = Release|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Release|x64.Build.0 = Release|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Release|x86.ActiveCfg = Release|Any CPU
+		{FA4B0E62-985B-4D07-83D0-5918FAE5735B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Closes #74. Phase 1 of the WorldForge epic (#72), building on the Phase 0 schema (#73). Stands up the `DolCon.WorldForge` CLI and proves the pipeline end-to-end: **Azgaar JSON in → valid `world.dol` out**. The game is **not** wired to consume `world.dol` yet (that's Phase 2) — it keeps loading raw Azgaar so nothing breaks mid-refactor.

## What's in it

**New CLI project `DolCon.WorldForge`** (`worldforge`, .NET 10, references `DolCon.Core`):
```
worldforge bake <azgaar-export.json> -o <world.dol> [--seed <int>]
```
Deserializes an Azgaar export, bakes it, writes `world.dol`, and prints a summary (cells, burgs, City of Light, locations placed), streaming progress through the existing `IMapProvisioningCallback`.

**Provisioning lifted into a shared, deterministic home.** `MapService.ProvisionMap()`'s world logic (City of Light selection, per-cell challenge ratings, cell/burg location placement, burg size adjustment) moved into `WorldProvisioningService` in `DolCon.Core` — one implementation now shared by the game and WorldForge. `MapService` keeps only player placement and delegates the rest.

**Deterministic bakes.** The non-seeded `new Random()` calls (and `Guid.NewGuid()` for location ids) are replaced by a single seeded `Random` threaded through the whole bake, so the same input + seed produces identical content. The seed is stored on `WorldInfo.ProvisioningSeed`. The game passes a fresh seed each load, preserving today's "flair differs every game" behaviour.

**Map → DolWorld converter** (`WorldBaker`) maps the provisioned Azgaar `Map` into the Phase 0 `DolWorld`, dropping the unused Azgaar bulk.

> **Architecture note:** the shared provisioning/baking logic lives in `DolCon.Core` (not the CLI exe) because the game still provisions raw Azgaar until Phase 2 and can't reference the CLI. WorldForge is a thin shell over it. This satisfies "single home, not duplicated in the game."

## Acceptance criteria

- ✅ Running the CLI on a `PrebuiltMaps` export produces a `world.dol` that deserializes into a complete `DolWorld` (verified on the real Ouvia map: 6,095 cells, 450 burgs, City of Light = Lympsin, 43,620 locations).
- ✅ Two bakes with the same seed produce identical output (verified byte-for-byte on the real map, ignoring the `generatedAt` provenance timestamp).
- ✅ Provisioning logic now has a single home, not duplicated in the game.

## Tests

`DolCon.Core.Tests/World/WorldBakerTests.cs` + `WorldProvisioningServiceTests.cs`: expected counts, stable City of Light, same-seed determinism, different-seed divergence, serializer round-trip, plus the moved `CalculateChallengeRating`/`AdjustBurgSize` unit tests. **All 275 Core tests pass; full solution builds clean (0 warnings).**

## Out of scope (Phase 2, #75)

Game loading `world.dol` and retiring runtime provisioning. Until then the game still loads raw Azgaar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)