### PR TITLE
Phase 2 — Game loads world.dol, retire runtime provisioning (#75)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,18 +14,22 @@ The solution consists of 3 projects:
 dol-con-v2/
 ├── DolCon.Core/           # Shared game logic library (Models, Services, Enums, Data)
 ├── DolCon.Core.Tests/     # Tests for Core library
-├── DolCon.MonoGame/       # MonoGame graphical application
+├── DolCon.MonoGame/       # MonoGame graphical application (loads world.dol)
+├── DolCon.WorldForge/     # CLI that bakes Azgaar exports into canonical world.dol
 ├── version.json           # Semantic versioning
 └── Directory.Build.props  # Shared build properties
 ```
 
 ### DolCon.Core (Shared Library)
 Contains all UI-agnostic game logic:
-- **Models/**: Player, Party, Item, Location, Scene, Combat models, BaseTypes (Map data)
-- **Services/**: CombatService, MapService, MoveService, EventService, ShopService, SaveGameService
+- **Models/**: Player, Party, Item, Scene, Combat models, `Models/World/` (the `DolWorld` canonical schema + `SaveGame`), BaseTypes (raw Azgaar Map data, WorldForge input)
+- **Services/**: CombatService, MapService, MoveService, EventService, ShopService, SaveGameService, WorldProvisioningService, WorldBaker
 - **Data/**: EnemyIndex (100+ enemies), EncounterBuilder
 - **Enums/**: Game enums (Direction, Biome, Equipment, CombatEnums, etc.)
 - **Utilities/**: PaginatedList
+
+### DolCon.WorldForge (CLI)
+Bakes a raw Azgaar export into a canonical `world.dol`: `worldforge bake <azgaar-export.json> -o <world.dol> [--seed <int>]`. See `docs/WORLD_DOL_FORMAT.md`.
 
 ### DolCon.MonoGame (Graphical Application)
 MonoGame-based UI:
@@ -75,8 +79,9 @@ dotnet restore
 
 Services are located in `DolCon.Core/Services/` and handle core game logic:
 
-- **SaveGameService**: Manages game save/load operations. Contains static properties for global game state: `CurrentMap`, `Party`, `CurrentCell`, `CurrentBurg`, `CurrentLocation`, `CurrentProvince`, `CurrentState`, `CurrentBiome`, and `CurrentPlayerId`.
-- **MapService**: Loads map JSON files from `%APPDATA%/DolCon/Maps`, handles direction calculations between coordinates, and generates location types for cells and burgs.
+- **SaveGameService**: Manages game save/load operations. Contains static properties for global game state: `CurrentWorld` (a `DolWorld`), `Party`, `CurrentCell`, `CurrentBurg`, `CurrentLocation`, `CurrentProvince`, `CurrentState`, `CurrentBiome`, and `CurrentPlayerId`. Save files are a `SaveGame` (`DolWorld` + party + player progress); the shipped, progress-free `world.dol` is loaded for new games.
+- **MapService**: Loads a baked `world.dol` (`DolWorld`) from `%APPDATA%/DolCon/Worlds` via `DolWorldSerializer`, installs shipped worlds on first run, and handles direction calculations. It no longer provisions the world at runtime — only player placement happens at load. World provisioning lives in `WorldProvisioningService` and is pre-baked by WorldForge.
+- **WorldProvisioningService / WorldBaker**: The single home for world provisioning (City of Light, challenge ratings, location placement, burg sizing), made deterministic via a seeded RNG. `WorldBaker` provisions an Azgaar `Map` and maps it to a `DolWorld`. Consumed by the `DolCon.WorldForge` CLI (`worldforge bake`), not by the game at runtime.
 - **PlayerService**: Manages player creation and persistence.
 - **MoveService**: Handles party movement between cells, calculates movement costs based on biome, and manages stamina consumption.
 - **EventService**: Processes events when entering locations (exploration, rewards, services, combat encounters).
@@ -112,7 +117,7 @@ Models are in `DolCon.Core/Models/`:
 
 1. Application starts via MonoGame's `Game1` class which initializes the ScreenManager.
 2. MainMenuScreen presents New Game or Load Game options.
-3. Player selection populates `SaveGameService.CurrentMap` and `SaveGameService.Party`.
+3. New Game loads a baked `world.dol` into `SaveGameService.CurrentWorld` and places the player; the world is no longer re-provisioned at runtime, so City of Light, challenge ratings, and locations are identical run-to-run.
 4. User navigates between screens using keyboard input handled by InputManager.
 5. Movement handled by `MoveService`, which updates Party position and triggers `EventService`.
 6. Events determine scene type (exploration rewards, shop interaction, services, combat).
@@ -121,7 +126,7 @@ Models are in `DolCon.Core/Models/`:
 
 ### Key Data Patterns
 
-- **Static State**: `SaveGameService.CurrentMap` and `SaveGameService.Party` are static and accessed globally throughout services.
+- **Static State**: `SaveGameService.CurrentWorld` (a `DolWorld`) and `SaveGameService.Party` are static and accessed globally throughout services. The game depends only on `DolWorld`; raw Azgaar shapes (`Models/BaseTypes`) are now an input to WorldForge, not used at runtime.
 - **Scene Management**: The Scene model acts as a state machine for multi-step interactions, tracking completion and selections.
 - **Currency System**: Coin values use integer math: 1 gold = 100 silver = 1000 copper = 1000 coin.
 
@@ -129,7 +134,8 @@ Models are in `DolCon.Core/Models/`:
 
 - **Items.json**: Defines all items/equipment with tags (TagType enum) for categorization.
 - **Services.json**: Defines available services at locations (inns, vendors, etc.).
-- **PrebuiltMaps/**: Contains pre-generated world maps that are copied to `%APPDATA%/DolCon/Maps` on first run.
+- **Worlds/**: Contains baked `world.dol` files (produced by WorldForge) that ship with the game and are copied to `%APPDATA%/DolCon/Worlds` on first run.
+- **PrebuiltMaps/**: Raw Azgaar exports kept in-repo only as WorldForge input; no longer copied to the game at runtime.
 
 ### Combat System
 

--- a/DolCon.Core.Tests/World/GameWorldStateTests.cs
+++ b/DolCon.Core.Tests/World/GameWorldStateTests.cs
@@ -1,0 +1,100 @@
+namespace DolCon.Core.Tests.World;
+
+using DolCon.Core.Enums;
+using DolCon.Core.Models;
+using DolCon.Core.Models.World;
+using DolCon.Core.Services;
+using FluentAssertions;
+
+/// <summary>
+/// Covers the Phase 2 contract: the game runs off a <see cref="DolWorld"/>, per-playthrough progress
+/// rides in the save (not the canonical world.dol), and the static save-state accessors resolve.
+/// </summary>
+public class GameWorldStateTests
+{
+    private static DolWorld BuildWorld()
+    {
+        var locationId = Guid.NewGuid();
+        return new DolWorld
+        {
+            Info = new WorldInfo { Name = "Testland" },
+            // Biome names parallel the Biome enum, so name[i] == (Biome)i (index 4 == Grassland).
+            Biomes = new List<string> { "Marine", "Hot desert", "Cold desert", "Savanna", "Grassland" },
+            States = new List<WorldState> { new() { Id = 0, Name = "Aurelia", FullName = "Kingdom of Aurelia" } },
+            Provinces = new List<WorldProvince> { new() { Id = 0, Name = "Dawnmoor", FullName = "Province of Dawnmoor" } },
+            Cells = new List<WorldCell>
+            {
+                new() { Id = 0, Center = new[] { 5.0, 5.0 }, Area = 120, Pop = 0.1m, Biome = 4, State = 0, Province = 0, Burg = 7,
+                    Locations = new List<WorldLocation> { new() { Id = locationId, Name = "Tavern", TypeKey = "tavern", Rarity = Rarity.Common } } }
+            },
+            Burgs = new List<WorldBurg>
+            {
+                new() { Id = 7, Name = "Lumengarde", Cell = 0, Population = 1050, Size = BurgSize.City, IsCityOfLight = true,
+                    Locations = new List<WorldLocation> { new() { Id = locationId, Name = "Lumengarde Tavern", TypeKey = "tavern", Rarity = Rarity.Common } } }
+            }
+        };
+    }
+
+    [Fact]
+    public void SaveGameService_Accessors_ResolveFromLoadedWorld()
+    {
+        SaveGameService.CurrentWorld = BuildWorld();
+        SaveGameService.Party = new Party { Cell = 0, Burg = 7 };
+
+        SaveGameService.HasWorld.Should().BeTrue();
+        SaveGameService.CurrentCell.Id.Should().Be(0);
+        SaveGameService.CurrentBurg!.Name.Should().Be("Lumengarde");
+        SaveGameService.CurrentBiome.Should().Be("Grassland");
+        SaveGameService.CurrentProvince.FullName.Should().Be("Province of Dawnmoor");
+        SaveGameService.CurrentState.Name.Should().Be("Aurelia");
+        SaveGameService.CurrentCell.BiomeType.Should().Be(Biome.Grassland);
+    }
+
+    [Fact]
+    public void SaveGameService_CurrentLocation_ResolvesFromBurg()
+    {
+        var world = BuildWorld();
+        var locationId = world.Burgs[0].Locations[0].Id;
+        SaveGameService.CurrentWorld = world;
+        SaveGameService.Party = new Party { Cell = 0, Burg = 7, Location = locationId };
+
+        SaveGameService.CurrentLocation.Should().NotBeNull();
+        SaveGameService.CurrentLocation!.Id.Should().Be(locationId);
+    }
+
+    [Fact]
+    public void CleanBake_OmitsPlayerProgressFields()
+    {
+        var json = DolWorldSerializer.Serialize(BuildWorld());
+
+        json.Should().NotContain("exploredPercent");
+        json.Should().NotContain("discovered");
+        json.Should().NotContain("lastExplored");
+    }
+
+    [Fact]
+    public void SaveGame_PersistsProgressOverTheWorld()
+    {
+        var world = BuildWorld();
+        world.Cells[0].ExploredPercent = 0.5;
+        world.Cells[0].Locations[0].Discovered = true;
+        world.Cells[0].Locations[0].ExploredPercent = 0.25;
+
+        var save = new SaveGame
+        {
+            World = world,
+            Party = new Party { Cell = 0, Burg = 7, Stamina = 0.8 },
+            CurrentPlayerId = Guid.NewGuid()
+        };
+
+        var json = System.Text.Json.JsonSerializer.Serialize(save, DolWorldSerializer.Options);
+        var restored = System.Text.Json.JsonSerializer.Deserialize<SaveGame>(json, DolWorldSerializer.Options);
+
+        restored.Should().NotBeNull();
+        restored!.Party.Cell.Should().Be(0);
+        restored.CurrentPlayerId.Should().Be(save.CurrentPlayerId);
+        restored.World.Cells[0].ExploredPercent.Should().Be(0.5);
+        restored.World.Cells[0].Locations[0].Discovered.Should().BeTrue();
+        restored.World.Cells[0].Locations[0].ExploredPercent.Should().Be(0.25);
+    }
+}

--- a/DolCon.Core/Models/Event.cs
+++ b/DolCon.Core/Models/Event.cs
@@ -1,15 +1,15 @@
-﻿using DolCon.Core.Models.BaseTypes;
+﻿using DolCon.Core.Models.World;
 
 namespace DolCon.Core.Models;
 
 public class Event
 {
-    public Event(Location? currentLocation, Cell currentCell)
+    public Event(WorldLocation? currentLocation, WorldCell currentCell)
     {
         Location = currentLocation;
         Area = currentCell;
     }
 
-    public Location? Location { get; set; }
-    public Cell Area { get; set; }
+    public WorldLocation? Location { get; set; }
+    public WorldCell Area { get; set; }
 }

--- a/DolCon.Core/Models/LocationType.cs
+++ b/DolCon.Core/Models/LocationType.cs
@@ -24,6 +24,12 @@ public record LocationType(
 
 public static class LocationTypes
 {
+    private static readonly Lazy<Dictionary<string, LocationType>> ByKey =
+        new(() => Types!.ToDictionary(t => t.Type));
+
+    /// <summary>Resolves a <see cref="LocationType"/> by its unique <see cref="LocationType.Type"/> key.</summary>
+    public static LocationType Get(string typeKey) => ByKey.Value[typeKey];
+
     public static List<LocationType> Types { get; } = new()
     {
         new LocationType(

--- a/DolCon.Core/Models/Scene.cs
+++ b/DolCon.Core/Models/Scene.cs
@@ -2,6 +2,7 @@
 
 using Combat;
 using Enums;
+using World;
 
 public class Scene
 {
@@ -14,7 +15,7 @@ public class Scene
     public Dictionary<int, ShopSelection> Selections { get; set; } = new();
     public ServiceType? SelectedService { get; set; }
     public int Selection { get; set; }
-    public Location? Location { get; set; }
+    public WorldLocation? Location { get; set; }
 
     // Combat-specific properties
     public CombatState? CombatState { get; set; }

--- a/DolCon.Core/Models/World/SaveGame.cs
+++ b/DolCon.Core/Models/World/SaveGame.cs
@@ -1,0 +1,16 @@
+namespace DolCon.Core.Models.World;
+
+using DolCon.Core.Models;
+
+/// <summary>
+/// A persisted save game: the canonical <see cref="DolWorld"/> plus the per-playthrough state laid
+/// over it (party, active player, and the exploration/discovery progress carried on the world's
+/// cells and locations). This is what gets written to a save file — distinct from the shipped,
+/// progress-free <c>world.dol</c>.
+/// </summary>
+public class SaveGame
+{
+    public DolWorld World { get; set; } = new();
+    public Party Party { get; set; } = new();
+    public Guid CurrentPlayerId { get; set; }
+}

--- a/DolCon.Core/Models/World/WorldCell.cs
+++ b/DolCon.Core/Models/World/WorldCell.cs
@@ -1,5 +1,8 @@
 namespace DolCon.Core.Models.World;
 
+using System.Text.Json.Serialization;
+using DolCon.Core.Enums;
+
 /// <summary>
 /// A Voronoi cell of the world. Holds the Azgaar geometry the game renders/navigates plus the
 /// baked challenge rating and generated locations that used to be re-rolled at runtime.
@@ -38,6 +41,30 @@ public class WorldCell
     /// <summary>Baked, generated locations for this cell.</summary>
     public List<WorldLocation> Locations { get; set; } = new();
 
+    /// <summary>
+    /// Per-playthrough exploration progress (0–1). Runtime/save state, not canonical world data —
+    /// omitted from a freshly baked world.dol (it's 0) and only written into save files once explored.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public double ExploredPercent { get; set; }
+
     /// <summary>Reserved enrichment for this cell. Optional; omitted when null.</summary>
     public Enrichment? Enrichment { get; set; }
+
+    /// <summary>Biome enum derived from the <see cref="Biome"/> index (movement cost, map colours).</summary>
+    [JsonIgnore]
+    public Biome BiomeType => (Biome)Biome;
+
+    /// <summary>Size bucket derived from <see cref="Area"/> (drives exploration/movement maths).</summary>
+    [JsonIgnore]
+    public CellSize CellSize => Area < 100 ? CellSize.small : CellSize.large;
+
+    /// <summary>Population density derived from <see cref="Pop"/>.</summary>
+    [JsonIgnore]
+    public PopDensity PopDensity => (Pop * 1000) switch
+    {
+        < (int)PopDensity.rural => PopDensity.wild,
+        < (int)PopDensity.urban => PopDensity.rural,
+        _ => PopDensity.urban
+    };
 }

--- a/DolCon.Core/Models/World/WorldLocation.cs
+++ b/DolCon.Core/Models/World/WorldLocation.cs
@@ -1,12 +1,14 @@
 namespace DolCon.Core.Models.World;
 
+using System.Text.Json.Serialization;
+using DolCon.Core.Models;
 using Enums;
 
 /// <summary>
-/// A baked location definition placed on a cell or burg. Stores only the static identity — the
-/// full <c>LocationType</c> template is rehydrated at load time from the <c>LocationTypes.Types</c>
-/// catalog via <see cref="TypeKey"/>. Per-playthrough exploration/discovery state is NOT stored
-/// here; it lives in the save game.
+/// A baked location placed on a cell or burg. Stores the static identity — the full
+/// <c>LocationType</c> template is rehydrated from the <c>LocationTypes.Types</c> catalog via
+/// <see cref="TypeKey"/>. Per-playthrough exploration/discovery is runtime/save state: it's omitted
+/// from a freshly baked world.dol and only written into save files once the player makes progress.
 /// </summary>
 public class WorldLocation
 {
@@ -25,4 +27,20 @@ public class WorldLocation
 
     /// <summary>Reserved enrichment for this location. Optional; omitted when null.</summary>
     public Enrichment? Enrichment { get; set; }
+
+    /// <summary>Whether the player has discovered this location. Runtime/save state.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool Discovered { get; set; }
+
+    /// <summary>Per-playthrough exploration progress (0–1). Runtime/save state.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public double ExploredPercent { get; set; }
+
+    /// <summary>When the location was last explored. Runtime/save state.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public DateTime LastExplored { get; set; }
+
+    /// <summary>The full location template, rehydrated from the static catalog by <see cref="TypeKey"/>.</summary>
+    [JsonIgnore]
+    public LocationType Type => LocationTypes.Get(TypeKey);
 }

--- a/DolCon.Core/Services/EventService.cs
+++ b/DolCon.Core/Services/EventService.cs
@@ -176,14 +176,14 @@ public class EventService : IEventService
             if (Math.Abs(currentCell.ExploredPercent - 1) < .01)
             {
                 currentCell.ExploredPercent = 1;
-                currentCell.locations.ForEach(x => x.Discovered = true);
+                currentCell.Locations.ForEach(x => x.Discovered = true);
             }
             else
             {
                 // Roll for location discovery
                 var chance = new Chance();
                 var dice = chance.Dice(20);
-                var undiscoveredLocations = currentCell.locations.Where(x => !x.Discovered).ToList();
+                var undiscoveredLocations = currentCell.Locations.Where(x => !x.Discovered).ToList();
 
                 if (dice > 0 && undiscoveredLocations.Count > 0)
                 {

--- a/DolCon.Core/Services/MapService.cs
+++ b/DolCon.Core/Services/MapService.cs
@@ -1,21 +1,20 @@
 namespace DolCon.Core.Services;
 
-using System.Text.Json;
 using DolCon.Core.Enums;
 using DolCon.Core.Models;
-using DolCon.Core.Models.BaseTypes;
+using DolCon.Core.Models.World;
 
 public interface IMapService
 {
-    IEnumerable<FileInfo> GetMaps();
-    void LoadMap(FileInfo mapFile);
-    void LoadMap(FileInfo mapFile, IMapProvisioningCallback callback);
-    void LoadMap(FileInfo mapFile, string playerName, PlayerAbilities abilities);
-    void LoadMap(FileInfo mapFile, IMapProvisioningCallback callback, string playerName, PlayerAbilities abilities);
+    IEnumerable<FileInfo> GetWorlds();
+    void LoadWorld(FileInfo worldFile, string playerName, PlayerAbilities abilities);
+    void LoadWorld(FileInfo worldFile, IMapProvisioningCallback callback, string playerName, PlayerAbilities abilities);
 }
 
 public class MapService : IMapService
 {
+    public const string WorldFileExtension = ".world.dol";
+
     public static Direction GetDirection(double ax, double ay, double bx, double by)
     {
         var angle = Math.Atan2(by - ay, bx - ax);
@@ -26,100 +25,74 @@ public class MapService : IMapService
         return (Direction)halfQuarter;
     }
 
-    private readonly string _mapsPath;
+    private readonly string _worldsPath;
     private readonly IPlayerService _playerService;
     private readonly IPositionUpdateHandler _positionUpdateHandler;
-    private readonly IWorldProvisioningService _worldProvisioningService;
 
-    public MapService(IPlayerService playerService, IPositionUpdateHandler positionUpdateHandler,
-        IWorldProvisioningService worldProvisioningService)
+    public MapService(IPlayerService playerService, IPositionUpdateHandler positionUpdateHandler)
     {
         _playerService = playerService;
         _positionUpdateHandler = positionUpdateHandler;
-        _worldProvisioningService = worldProvisioningService;
         var mainPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "DolCon");
-        _mapsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "DolCon",
-            "Maps");
-        if (Directory.Exists(_mapsPath)) return;
+        _worldsPath = Path.Combine(mainPath, "Worlds");
+        if (Directory.Exists(_worldsPath)) return;
 
-        Directory.CreateDirectory(mainPath);
+        Directory.CreateDirectory(_worldsPath);
 
-        // Move pre-built maps if they exist
-        var prebuiltPath = Environment.CurrentDirectory + "/PrebuiltMaps";
-        if (Directory.Exists(prebuiltPath))
+        // Install the baked worlds that ship with the game on first run.
+        var shippedWorlds = Path.Combine(Environment.CurrentDirectory, "Worlds");
+        if (!Directory.Exists(shippedWorlds)) return;
+        foreach (var world in Directory.GetFiles(shippedWorlds, $"*{WorldFileExtension}"))
         {
-            Directory.Move(prebuiltPath, _mapsPath);
+            File.Copy(world, Path.Combine(_worldsPath, Path.GetFileName(world)), overwrite: true);
         }
     }
 
-    public MapService(IPlayerService playerService)
-        : this(playerService, new NoOpPositionUpdateHandler(), new WorldProvisioningService())
+    public MapService(IPlayerService playerService) : this(playerService, new NoOpPositionUpdateHandler())
     {
     }
 
-    public IEnumerable<FileInfo> GetMaps()
+    public IEnumerable<FileInfo> GetWorlds()
     {
-        var maps = new DirectoryInfo(_mapsPath).GetFiles("*.json");
-        return maps;
+        return new DirectoryInfo(_worldsPath).GetFiles($"*{WorldFileExtension}");
     }
 
-    public void LoadMap(FileInfo mapFile)
+    public void LoadWorld(FileInfo worldFile, string playerName, PlayerAbilities abilities)
     {
-        LoadMap(mapFile, new NoOpMapProvisioningCallback());
+        LoadWorld(worldFile, new NoOpMapProvisioningCallback(), playerName, abilities);
     }
 
-    public void LoadMap(FileInfo mapFile, IMapProvisioningCallback callback)
+    public void LoadWorld(FileInfo worldFile, IMapProvisioningCallback callback, string playerName,
+        PlayerAbilities abilities)
     {
-        callback.OnStatus("Loading map...");
-        var map = DeserializeMap(mapFile).Result ?? throw new DolMapException("Failed to load map");
-        callback.OnEvent($"Loaded map {mapFile.Name}");
-        ProvisionMap(callback, map);
-        SaveGameService.CurrentMap = map;
+        callback.OnStatus("Loading world...");
+        var world = DolWorldSerializer.Deserialize(File.ReadAllText(worldFile.FullName))
+                    ?? throw new DolMapException("Failed to load world");
+        callback.OnEvent($"Loaded world {world.Info.Name}");
+
+        SaveGameService.CurrentWorld = world;
+
+        // The world is pre-baked (City of Light, challenge ratings, locations all provisioned by
+        // WorldForge). Only per-playthrough player placement happens here.
+        PlacePlayer(callback, world, playerName, abilities);
     }
 
-    public void LoadMap(FileInfo mapFile, string playerName, PlayerAbilities abilities)
+    private void PlacePlayer(IMapProvisioningCallback callback, DolWorld world, string playerName,
+        PlayerAbilities abilities)
     {
-        LoadMap(mapFile, new NoOpMapProvisioningCallback(), playerName, abilities);
-    }
-
-    public void LoadMap(FileInfo mapFile, IMapProvisioningCallback callback, string playerName, PlayerAbilities abilities)
-    {
-        callback.OnStatus("Loading map...");
-        var map = DeserializeMap(mapFile).Result ?? throw new DolMapException("Failed to load map");
-        callback.OnEvent($"Loaded map {mapFile.Name}");
-        ProvisionMap(callback, map, playerName, abilities);
-        SaveGameService.CurrentMap = map;
-    }
-
-    private void ProvisionMap(IMapProvisioningCallback callback, Map map,
-        string? playerName = null, PlayerAbilities? abilities = null)
-    {
-        // World provisioning now lives in WorldProvisioningService (shared with WorldForge). The game
-        // still provisions at load time until Phase 2 wires it to consume world.dol. A fresh seed each
-        // load preserves today's "flair differs every game" behaviour.
-        _worldProvisioningService.Provision(map, Environment.TickCount, callback);
-
         callback.OnStatus("Setting player position...");
 
-        var cityOfLight = map.Collections.burgs.First(x => x.isCityOfLight);
+        var cityOfLight = world.Burgs.First(b => b.IsCityOfLight);
         SaveGameService.Party = new Party
         {
-            Cell = cityOfLight.cell,
-            Burg = cityOfLight.i,
+            Cell = cityOfLight.Cell,
+            Burg = cityOfLight.Id,
             Stamina = 1
         };
-        var player = abilities != null
-            ? _playerService.SetPlayer(playerName ?? "Player 1", false, abilities)
-            : _playerService.SetPlayer(playerName ?? "Player 1", false);
+        var player = _playerService.SetPlayer(playerName, false, abilities);
         SaveGameService.CurrentPlayerId = player.Id;
         _positionUpdateHandler.OnPositionUpdated();
 
-        callback.OnEvent($"Player position set to {cityOfLight.name}");
-    }
-
-    private static async Task<Map?> DeserializeMap(FileSystemInfo mapFile)
-    {
-        var stream = File.OpenRead(mapFile.FullName);
-        return await JsonSerializer.DeserializeAsync<Map>(stream);
+        callback.OnEvent($"Player position set to {cityOfLight.Name}");
     }
 }

--- a/DolCon.Core/Services/MoveService.cs
+++ b/DolCon.Core/Services/MoveService.cs
@@ -26,11 +26,11 @@ public class MoveService : IMoveService
     public MoveStatus MoveToCell(int cellId)
     {
         var party = SaveGameService.Party;
-        var cell = SaveGameService.CurrentMap.Collections.cells[cellId];
+        var cell = SaveGameService.GetCell(cellId);
 
         double baseMoveCost;
 
-        switch (cell.Biome)
+        switch (cell.BiomeType)
         {
             case Biome.Marine:
                 return MoveStatus.Blocked;

--- a/DolCon.Core/Services/SaveGameService.cs
+++ b/DolCon.Core/Services/SaveGameService.cs
@@ -2,7 +2,7 @@ namespace DolCon.Core.Services;
 
 using System.Text.Json;
 using DolCon.Core.Models;
-using DolCon.Core.Models.BaseTypes;
+using DolCon.Core.Models.World;
 
 public interface ISaveGameService
 {
@@ -14,30 +14,33 @@ public interface ISaveGameService
 
 public class SaveGameService : ISaveGameService
 {
-    public static Location? CurrentLocation =>
+    public static WorldLocation? CurrentLocation =>
         Party switch
         {
-            { Location: not null, Burg: not null } => CurrentMap.Collections.burgs
-                .Find(b => b.i == Party.Burg.Value)?.locations.FirstOrDefault(x => x.Id == Party.Location.Value),
-            { Location: not null } => CurrentMap.Collections.cells[Party.Cell]
-                .locations.FirstOrDefault(x => x.Id == Party.Location.Value),
+            { Location: not null, Burg: not null } => CurrentWorld.Burgs
+                .Find(b => b.Id == Party.Burg.Value)?.Locations.FirstOrDefault(x => x.Id == Party.Location.Value),
+            { Location: not null } => CurrentWorld.Cells[Party.Cell]
+                .Locations.FirstOrDefault(x => x.Id == Party.Location.Value),
             _ => null
         };
-    public static Map CurrentMap { get; set; } = new();
+    public static DolWorld CurrentWorld { get; set; } = new();
     public static Party Party { get; set; } = new();
     public static Guid CurrentPlayerId { get; set; } = Guid.NewGuid();
 
-    public static Cell CurrentCell => CurrentMap.Collections.cells[Party.Cell];
+    /// <summary>True once a baked world has been loaded (new game started or save loaded).</summary>
+    public static bool HasWorld => CurrentWorld.Cells.Count > 0;
 
-    public static Burg? CurrentBurg => Party.Burg.HasValue
-        ? CurrentMap.Collections.burgs.Find(b => b.i == Party.Burg.Value)
+    public static WorldCell CurrentCell => CurrentWorld.Cells[Party.Cell];
+
+    public static WorldBurg? CurrentBurg => Party.Burg.HasValue
+        ? CurrentWorld.Burgs.Find(b => b.Id == Party.Burg.Value)
         : null;
 
-    public static Province CurrentProvince => CurrentMap.Collections.provinces[CurrentCell.province];
+    public static WorldProvince CurrentProvince => CurrentWorld.Provinces[CurrentCell.Province];
 
-    public static State CurrentState => CurrentMap.Collections.states[CurrentCell.state];
+    public static WorldState CurrentState => CurrentWorld.States[CurrentCell.State];
 
-    public static string CurrentBiome => CurrentMap.biomes.name[CurrentCell.biome];
+    public static string CurrentBiome => CurrentWorld.Biomes[CurrentCell.Biome];
 
     public static string? CurrentSaveName { get; set; }
 
@@ -57,16 +60,15 @@ public class SaveGameService : ISaveGameService
         {
             var existingFiles = Directory.GetFiles(_savesPath, "*.json")
                 .Select(Path.GetFileName).ToArray();
-            var mapName = CurrentMap.info?.mapName ?? "unknown";
+            var worldName = string.IsNullOrEmpty(CurrentWorld.Info.Name) ? "unknown" : CurrentWorld.Info.Name;
             var player = Party.Players.FirstOrDefault(p => p.Id == CurrentPlayerId);
             var playerName = SanitizeFileComponent(player?.Name ?? "Unknown");
-            CurrentSaveName = GenerateSaveName(mapName, playerName, existingFiles!);
+            CurrentSaveName = GenerateSaveName(worldName, playerName, existingFiles!);
         }
 
         var saveGamePath = Path.Combine(_savesPath, $"{CurrentSaveName}.json");
-        CurrentMap.Party = Party;
-        CurrentMap.CurrentPlayerId = CurrentPlayerId;
-        await File.WriteAllTextAsync(saveGamePath, JsonSerializer.Serialize(CurrentMap));
+        var save = new SaveGame { World = CurrentWorld, Party = Party, CurrentPlayerId = CurrentPlayerId };
+        await File.WriteAllTextAsync(saveGamePath, JsonSerializer.Serialize(save, DolWorldSerializer.Options));
         return saveGamePath;
     }
 
@@ -78,12 +80,14 @@ public class SaveGameService : ISaveGameService
     public async Task LoadGame(FileInfo saveFile)
     {
         var fileStream = File.OpenRead(saveFile.FullName);
-        var map = await JsonSerializer.DeserializeAsync<Map>(fileStream);
+        var save = await JsonSerializer.DeserializeAsync<SaveGame>(fileStream, DolWorldSerializer.Options);
         fileStream.Close();
 
-        CurrentMap = map ?? throw new DolSaveGameException("Failed to load game");
-        Party = CurrentMap.Party;
-        CurrentPlayerId = CurrentMap.CurrentPlayerId;
+        if (save is null) throw new DolSaveGameException("Failed to load game");
+
+        CurrentWorld = save.World;
+        Party = save.Party;
+        CurrentPlayerId = save.CurrentPlayerId;
         CurrentSaveName = Path.GetFileNameWithoutExtension(saveFile.Name);
     }
 
@@ -99,29 +103,29 @@ public class SaveGameService : ISaveGameService
             saveFile.Delete();
     }
 
-    public static Cell GetCell(int cellId)
+    public static WorldCell GetCell(int cellId)
     {
-        return CurrentMap.Collections.cells[cellId];
+        return CurrentWorld.Cells[cellId];
     }
 
-    public static Burg? GetBurg(int cellBurg)
+    public static WorldBurg? GetBurg(int cellBurg)
     {
-        return CurrentMap.Collections.burgs.Find(x => x.i == cellBurg);
+        return CurrentWorld.Burgs.Find(x => x.Id == cellBurg);
     }
 
     public static string GetBiome(int cellBiome)
     {
-        return CurrentMap.biomes.name[cellBiome];
+        return CurrentWorld.Biomes[cellBiome];
     }
 
-    public static Province GetProvince(int cellProvince)
+    public static WorldProvince GetProvince(int cellProvince)
     {
-        return CurrentMap.Collections.provinces[cellProvince];
+        return CurrentWorld.Provinces[cellProvince];
     }
 
-    public static State GetState(int cellState)
+    public static WorldState GetState(int cellState)
     {
-        return CurrentMap.Collections.states[cellState];
+        return CurrentWorld.States[cellState];
     }
 
     public static string SanitizeFileComponent(string name)

--- a/DolCon.MonoGame/DolCon.MonoGame.csproj
+++ b/DolCon.MonoGame/DolCon.MonoGame.csproj
@@ -22,7 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="PrebuiltMaps\*.json">
+    <!-- Ship the baked canonical world(s); the game installs these to %APPDATA%/DolCon/Worlds on
+         first run. The raw Azgaar export under PrebuiltMaps is kept in-repo only as WorldForge input
+         and is no longer copied to output. -->
+    <None Update="Worlds\*.world.dol">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/DolCon.MonoGame/Game1.cs
+++ b/DolCon.MonoGame/Game1.cs
@@ -19,7 +19,7 @@ public static class SaveHelper
     /// </summary>
     public static void TriggerSave()
     {
-        if (SaveGameService.CurrentMap.info == null) return;
+        if (!SaveGameService.HasWorld) return;
 
         Task.Run(async () =>
         {
@@ -67,7 +67,7 @@ public class Game1 : Game
         // Initialize core services
         _playerService = new PlayerService();
         var positionHandler = new NoOpPositionUpdateHandler();
-        _mapService = new MapService(_playerService, positionHandler, new WorldProvisioningService());
+        _mapService = new MapService(_playerService, positionHandler);
         _moveService = new MoveService(positionHandler);
 
         var itemsService = new ItemsService();
@@ -141,7 +141,7 @@ public class Game1 : Game
     protected override void OnExiting(object sender, EventArgs args)
     {
         // Auto-save on exit
-        if (SaveGameService.CurrentMap.info != null)
+        if (SaveGameService.HasWorld)
         {
             _saveGameService.SaveGame().Wait();
         }

--- a/DolCon.MonoGame/Screens/BattleScreen.cs
+++ b/DolCon.MonoGame/Screens/BattleScreen.cs
@@ -65,8 +65,8 @@ public class BattleScreen : ScreenBase
 
         if (players.Count > 0)
         {
-            // Get biome type for enemy spawning (cell.biome is an index matching Biome enum)
-            var gameBiome = (Biome)cell.biome;
+            // Get biome type for enemy spawning
+            var gameBiome = cell.BiomeType;
             var biome = BiomeMapper.MapToCombatBiome(gameBiome);
 
             // Get challenge rating from cell (default to 1.0 if not set)

--- a/DolCon.MonoGame/Screens/CharacterCreationScreen.cs
+++ b/DolCon.MonoGame/Screens/CharacterCreationScreen.cs
@@ -231,11 +231,11 @@ public class CharacterCreationScreen : ScreenBase
 
     private void ConfirmCharacter()
     {
-        _mapService.LoadMap(_selectedMap, _playerName.Trim(), _abilities);
+        _mapService.LoadWorld(_selectedMap, _playerName.Trim(), _abilities);
 
         var existingFiles = _saveGameService.GetSaves()
             .Select(f => f.Name).ToArray();
-        var mapName = SaveGameService.CurrentMap.info?.mapName ?? "unknown";
+        var mapName = SaveGameService.CurrentWorld.Info.Name;
         var sanitizedName = SaveGameService.SanitizeFileComponent(_playerName.Trim());
         SaveGameService.CurrentSaveName = SaveGameService.GenerateSaveName(
             mapName, sanitizedName, existingFiles);

--- a/DolCon.MonoGame/Screens/HomeScreen.cs
+++ b/DolCon.MonoGame/Screens/HomeScreen.cs
@@ -56,7 +56,7 @@ public class HomeScreen : ScreenBase
         var biome = SaveGameService.CurrentBiome;
 
         int y = locationPanel.Y + 40;
-        DrawText(spriteBatch, $"Cell: {cell.i}", new Vector2(locationPanel.X + 10, y), Color.LightGray);
+        DrawText(spriteBatch, $"Cell: {cell.Id}", new Vector2(locationPanel.X + 10, y), Color.LightGray);
         y += 25;
         DrawText(spriteBatch, $"Biome: {biome}", new Vector2(locationPanel.X + 10, y), Color.LightGray);
         y += 25;
@@ -64,16 +64,16 @@ public class HomeScreen : ScreenBase
         // Show burg info - either the one we're in, or one nearby in the cell
         if (burg != null)
         {
-            DrawText(spriteBatch, $"In Burg: {burg.name} ({burg.size})", new Vector2(locationPanel.X + 10, y), Color.LightBlue);
+            DrawText(spriteBatch, $"In Burg: {burg.Name} ({burg.Size})", new Vector2(locationPanel.X + 10, y), Color.LightBlue);
             y += 25;
         }
         else
         {
             // Check if there's a burg in this cell we could enter
-            var cellBurg = SaveGameService.GetBurg(cell.burg);
+            var cellBurg = SaveGameService.GetBurg(cell.Burg);
             if (cellBurg != null)
             {
-                DrawText(spriteBatch, $"Nearby: {cellBurg.name} ({cellBurg.size})", new Vector2(locationPanel.X + 10, y), Color.Cyan);
+                DrawText(spriteBatch, $"Nearby: {cellBurg.Name} ({cellBurg.Size})", new Vector2(locationPanel.X + 10, y), Color.Cyan);
                 y += 25;
             }
         }

--- a/DolCon.MonoGame/Screens/LocationScreen.cs
+++ b/DolCon.MonoGame/Screens/LocationScreen.cs
@@ -3,7 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using DolCon.Core.Enums;
 using DolCon.Core.Models;
-using DolCon.Core.Models.BaseTypes;
+using DolCon.Core.Models.World;
 using DolCon.Core.Services;
 using DolCon.MonoGame.Input;
 
@@ -69,7 +69,7 @@ public class LocationScreen : ScreenBase
         if (burg != null)
         {
             // In a burg - show burg locations
-            foreach (var loc in burg.locations)
+            foreach (var loc in burg.Locations)
             {
                 var isExplorable = loc.Type.Size != LocationSize.unexplorable;
                 _locations.Add(new LocationDisplayItem(
@@ -84,7 +84,7 @@ public class LocationScreen : ScreenBase
         else
         {
             // In wilderness - show discovered cell locations
-            foreach (var loc in cell.locations.Where(l => l.Discovered))
+            foreach (var loc in cell.Locations.Where(l => l.Discovered))
             {
                 var isExplorable = loc.Type.Size != LocationSize.unexplorable;
                 _locations.Add(new LocationDisplayItem(
@@ -97,14 +97,14 @@ public class LocationScreen : ScreenBase
             }
 
             // Also check if there's a burg we can enter
-            var cellBurg = SaveGameService.GetBurg(cell.burg);
+            var cellBurg = SaveGameService.GetBurg(cell.Burg);
             if (cellBurg != null)
             {
                 // Add burg as a special "location" entry
                 _locations.Insert(0, new LocationDisplayItem(
                     Guid.Empty, // Special marker for burg
-                    cellBurg.name,
-                    $"Burg ({cellBurg.size})",
+                    cellBurg.Name,
+                    $"Burg ({cellBurg.Size})",
                     0,
                     true,
                     false));
@@ -251,19 +251,19 @@ public class LocationScreen : ScreenBase
     private void ProcessEnterBurg()
     {
         var cell = SaveGameService.CurrentCell;
-        var burg = SaveGameService.GetBurg(cell.burg);
+        var burg = SaveGameService.GetBurg(cell.Burg);
 
         if (burg != null)
         {
             var party = SaveGameService.Party;
-            party.Burg = burg.i;
-            _message = $"Entered {burg.name}";
+            party.Burg = burg.Id;
+            _message = $"Entered {burg.Name}";
             BuildLocationList();
             SaveHelper.TriggerSave();
         }
     }
 
-    private void ProcessExploration(Location location)
+    private void ProcessExploration(WorldLocation location)
     {
         var cell = SaveGameService.CurrentCell;
         var thisEvent = new Event(location, cell);
@@ -331,7 +331,7 @@ public class LocationScreen : ScreenBase
         var cell = SaveGameService.CurrentCell;
         var burg = SaveGameService.CurrentBurg;
         var location = SaveGameService.CurrentLocation;
-        var biome = SaveGameService.GetBiome(cell.biome);
+        var biome = SaveGameService.GetBiome(cell.Biome);
 
         if (location != null)
         {
@@ -371,7 +371,7 @@ public class LocationScreen : ScreenBase
         }
         else if (burg != null)
         {
-            DrawText(spriteBatch, $"In Burg: {burg.name} ({burg.size})", new Vector2(padding, y), Color.Cyan);
+            DrawText(spriteBatch, $"In Burg: {burg.Name} ({burg.Size})", new Vector2(padding, y), Color.Cyan);
             y += 25;
             DrawText(spriteBatch, $"Biome: {biome}", new Vector2(padding, y), Color.LightGray);
             y += 35;
@@ -380,7 +380,7 @@ public class LocationScreen : ScreenBase
         }
         else
         {
-            DrawText(spriteBatch, $"Wilderness - Cell {cell.i}", new Vector2(padding, y), Color.LightGray);
+            DrawText(spriteBatch, $"Wilderness - Cell {cell.Id}", new Vector2(padding, y), Color.LightGray);
             y += 25;
             DrawText(spriteBatch, $"Biome: {biome}", new Vector2(padding, y), Color.LightGray);
             y += 35;

--- a/DolCon.MonoGame/Screens/MainMenuScreen.cs
+++ b/DolCon.MonoGame/Screens/MainMenuScreen.cs
@@ -77,10 +77,10 @@ public class MainMenuScreen : ScreenBase
             switch (_selectedIndex)
             {
                 case 0: // New Game
-                    _availableMaps = _mapService.GetMaps().ToArray();
+                    _availableMaps = _mapService.GetWorlds().ToArray();
                     if (_availableMaps.Length == 0)
                     {
-                        _statusMessage = "No maps found! Place map files in %APPDATA%/DolCon/Maps/";
+                        _statusMessage = "No worlds found! Place world.dol files in %APPDATA%/DolCon/Worlds/";
                     }
                     else
                     {
@@ -203,8 +203,9 @@ public class MainMenuScreen : ScreenBase
                 DrawMenu(spriteBatch, _menuOptions, centerX, startY);
                 break;
             case MenuState.SelectMap:
-                DrawCenteredText(spriteBatch, "Select a Map", 150, Color.White);
-                var mapNames = _availableMaps.Select(m => m.Name).ToArray();
+                DrawCenteredText(spriteBatch, "Select a World", 150, Color.White);
+                var mapNames = _availableMaps
+                    .Select(m => m.Name.Replace(MapService.WorldFileExtension, string.Empty)).ToArray();
                 DrawMenu(spriteBatch, mapNames, centerX, startY);
                 DrawCenteredText(spriteBatch, "Press ESC to go back", 500, Color.Gray);
                 break;

--- a/DolCon.MonoGame/Screens/NavigationScreen.cs
+++ b/DolCon.MonoGame/Screens/NavigationScreen.cs
@@ -4,7 +4,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using DolCon.Core.Enums;
 using DolCon.Core.Models;
-using DolCon.Core.Models.BaseTypes;
+using DolCon.Core.Models.World;
 using DolCon.Core.Services;
 using DolCon.Core.Utilities;
 using DolCon.MonoGame.Input;
@@ -75,7 +75,7 @@ public class NavigationScreen : ScreenBase
         _cellPolygons.Clear();
         _maxSelectionNumber = 0;
 
-        var map = SaveGameService.CurrentMap;
+        var map = SaveGameService.CurrentWorld;
         var cell = SaveGameService.CurrentCell;
         var location = SaveGameService.CurrentLocation;
         var burg = SaveGameService.CurrentBurg;
@@ -83,70 +83,70 @@ public class NavigationScreen : ScreenBase
         // Check for special actions at current position
         _canExplore = location == null && burg == null;
         _canCamp = location == null && burg == null;
-        var cellBurg = SaveGameService.GetBurg(cell.burg);
+        var cellBurg = SaveGameService.GetBurg(cell.Burg);
         _canEnterBurg = cellBurg != null && burg == null;
-        _burgName = cellBurg?.name;
+        _burgName = cellBurg?.Name;
 
         // Collect all vertices for viewport calculation
         var allVertices = new List<(double X, double Y)>();
 
         // Add current cell
         var currentVerts = GetCellVertices(cell, map);
-        var centerProvince = SaveGameService.GetProvince(cell.province);
+        var centerProvince = SaveGameService.GetProvince(cell.Province);
         allVertices.AddRange(currentVerts.Select(v => ((double)v.X, (double)v.Y)));
 
         _cellPolygons.Add(new PolygonCellData(
-            cell.i,
-            cell.Biome,
+            cell.Id,
+            cell.BiomeType,
             cell.ExploredPercent,
-            cellBurg?.name,
-            centerProvince.fullName,
+            cellBurg?.Name,
+            centerProvince.FullName,
             true,
             null,
             false,
             currentVerts,
-            new Vector2((float)cell.p[0], (float)cell.p[1])));
+            new Vector2((float)cell.Center[0], (float)cell.Center[1])));
 
         // Build neighbor inputs for clockwise sorting
         var neighborInputs = new List<ClockwiseNeighborSorter.NeighborInput>();
-        var neighborData = new Dictionary<int, (Cell Cell, Vector2[] Verts, Burg? Burg, Province Province)>();
+        var neighborData = new Dictionary<int, (WorldCell Cell, Vector2[] Verts, WorldBurg? Burg, WorldProvince Province)>();
 
-        foreach (var neighborId in cell.c)
+        foreach (var neighborId in cell.Neighbors)
         {
             if (neighborId < 0) continue;
 
             var neighbor = SaveGameService.GetCell(neighborId);
             var nVerts = GetCellVertices(neighbor, map);
-            var nBurg = SaveGameService.GetBurg(neighbor.burg);
-            var nProvince = SaveGameService.GetProvince(neighbor.province);
-            var isBlocked = neighbor.Biome == Biome.Marine;
+            var nBurg = SaveGameService.GetBurg(neighbor.Burg);
+            var nProvince = SaveGameService.GetProvince(neighbor.Province);
+            var isBlocked = neighbor.BiomeType == Biome.Marine;
 
             neighborData[neighborId] = (neighbor, nVerts, nBurg, nProvince);
             neighborInputs.Add(new ClockwiseNeighborSorter.NeighborInput(
-                neighborId, neighbor.p[0], neighbor.p[1], isBlocked));
+                neighborId, neighbor.Center[0], neighbor.Center[1], isBlocked));
 
             allVertices.AddRange(nVerts.Select(v => ((double)v.X, (double)v.Y)));
         }
 
         // Sort neighbors clockwise from north
         var sorted = ClockwiseNeighborSorter.SortNeighborsClockwise(
-            cell.p[0], cell.p[1], neighborInputs);
+            cell.Center[0], cell.Center[1], neighborInputs);
 
         foreach (var entry in sorted)
         {
             var (neighbor, verts, nBurg, province) = neighborData[entry.CellId];
 
             _cellPolygons.Add(new PolygonCellData(
-                neighbor.i,
-                neighbor.Biome,
+                neighbor.Id,
+                neighbor.BiomeType,
                 neighbor.ExploredPercent,
-                nBurg?.name,
-                province.fullName,
+                nBurg?.Name,
+                province.FullName,
                 false,
                 entry.SelectionNumber,
-                neighbor.Biome == Biome.Marine,
+                neighbor.BiomeType == Biome.Marine,
                 verts,
-                new Vector2((float)neighbor.p[0], (float)neighbor.p[1])));
+                new Vector2((float)neighbor.Center[0], (float)neighbor.Center[1])));
 
             if (entry.SelectionNumber.HasValue)
                 _maxSelectionNumber = entry.SelectionNumber.Value;
@@ -159,19 +159,19 @@ public class NavigationScreen : ScreenBase
         _viewport = new CellClusterViewport(allVertices, polyAreaWidth, polyAreaHeight);
     }
 
-    private Vector2[] GetCellVertices(Cell cell, Map map)
+    private Vector2[] GetCellVertices(WorldCell cell, DolWorld map)
     {
-        if (cell.v == null || cell.v.Count < 3)
+        if (cell.VertexIndices == null || cell.VertexIndices.Count < 3)
             return Array.Empty<Vector2>();
 
-        var vertices = new List<Vector2>(cell.v.Count);
-        for (int i = 0; i < cell.v.Count; i++)
+        var vertices = new List<Vector2>(cell.VertexIndices.Count);
+        for (int i = 0; i < cell.VertexIndices.Count; i++)
         {
-            int vi = cell.v[i];
-            if (vi >= 0 && vi < map.vertices.Count)
+            int vi = cell.VertexIndices[i];
+            if (vi >= 0 && vi < map.Vertices.Count)
             {
-                var v = map.vertices[vi];
-                vertices.Add(new Vector2((float)v.p[0], (float)v.p[1]));
+                var v = map.Vertices[vi];
+                vertices.Add(new Vector2((float)v.P[0], (float)v.P[1]));
             }
         }
         return vertices.ToArray();
@@ -316,12 +316,12 @@ public class NavigationScreen : ScreenBase
     private void ProcessEnterBurg()
     {
         var cell = SaveGameService.CurrentCell;
-        var cellBurg = SaveGameService.GetBurg(cell.burg);
+        var cellBurg = SaveGameService.GetBurg(cell.Burg);
         if (cellBurg != null)
         {
             var party = SaveGameService.Party;
-            party.Burg = cellBurg.i;
-            _message = $"Entered {cellBurg.name}";
+            party.Burg = cellBurg.Id;
+            _message = $"Entered {cellBurg.Name}";
             SaveHelper.TriggerSave();
             BuildPolygonData();
         }
@@ -375,7 +375,7 @@ public class NavigationScreen : ScreenBase
         var burg = SaveGameService.CurrentBurg;
         if (burg != null)
         {
-            DrawText(spriteBatch, $"In Burg: {burg.name} ({burg.size})", new Vector2(20, 85), Color.Cyan);
+            DrawText(spriteBatch, $"In Burg: {burg.Name} ({burg.Size})", new Vector2(20, 85), Color.Cyan);
         }
 
         // Polygon area background
@@ -576,9 +576,9 @@ public class NavigationScreen : ScreenBase
 
         // Current cell info
         var cell = SaveGameService.CurrentCell;
-        DrawText(spriteBatch, $"Cell: {cell.i}", new Vector2(panelX + 15, y), Color.LightGray);
+        DrawText(spriteBatch, $"Cell: {cell.Id}", new Vector2(panelX + 15, y), Color.LightGray);
         y += 22;
-        DrawText(spriteBatch, $"Biome: {FormatBiomeName(cell.Biome)}", new Vector2(panelX + 15, y), Color.LightGray);
+        DrawText(spriteBatch, $"Biome: {FormatBiomeName(cell.BiomeType)}", new Vector2(panelX + 15, y), Color.LightGray);
         y += 22;
         DrawText(spriteBatch, $"Explored: {cell.ExploredPercent:P0}", new Vector2(panelX + 15, y), Color.LightGray);
         y += 30;
@@ -592,7 +592,7 @@ public class NavigationScreen : ScreenBase
 
         if (burg != null)
         {
-            DrawText(spriteBatch, $"In Burg: {burg.name}", new Vector2(panelX + 15, y), Color.Cyan);
+            DrawText(spriteBatch, $"In Burg: {burg.Name}", new Vector2(panelX + 15, y), Color.Cyan);
             y += 22;
             DrawText(spriteBatch, "[L] Explore Locations", new Vector2(panelX + 15, y), Color.Orange);
             y += 22;

--- a/DolCon.MonoGame/Screens/WorldMapScreen.cs
+++ b/DolCon.MonoGame/Screens/WorldMapScreen.cs
@@ -3,7 +3,7 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using DolCon.Core.Enums;
-using DolCon.Core.Models.BaseTypes;
+using DolCon.Core.Models.World;
 using DolCon.Core.Services;
 using DolCon.Core.Utilities;
 using DolCon.MonoGame.Input;
@@ -30,7 +30,7 @@ public class WorldMapScreen : ScreenBase
     private const int ControlsBarHeight = 70;
 
     private readonly Dictionary<int, float> _cellVisibility = new();
-    private Burg? _cityOfLight;
+    private WorldBurg? _cityOfLight;
     private bool _needsCenter = true;
     private PolygonRenderer? _polygonRenderer;
 
@@ -40,8 +40,8 @@ public class WorldMapScreen : ScreenBase
 
         PrecomputeVisibility();
 
-        _cityOfLight = SaveGameService.CurrentMap.Collections.burgs
-            .FirstOrDefault(b => b.isCityOfLight);
+        _cityOfLight = SaveGameService.CurrentWorld.Burgs
+            .FirstOrDefault(b => b.IsCityOfLight);
     }
 
     public override void LoadContent(ContentManager content, GraphicsDevice graphicsDevice)
@@ -60,7 +60,7 @@ public class WorldMapScreen : ScreenBase
     private void PrecomputeVisibility()
     {
         _cellVisibility.Clear();
-        var cells = SaveGameService.CurrentMap.Collections.cells;
+        var cells = SaveGameService.CurrentWorld.Cells;
         var currentCellId = SaveGameService.Party.Cell;
 
         // Always show the player's current cell at full visibility
@@ -71,9 +71,9 @@ public class WorldMapScreen : ScreenBase
         {
             if (cell.ExploredPercent > 0)
             {
-                _cellVisibility[cell.i] = (float)Math.Max(
+                _cellVisibility[cell.Id] = (float)Math.Max(
                     cell.ExploredPercent,
-                    _cellVisibility.GetValueOrDefault(cell.i, 0f));
+                    _cellVisibility.GetValueOrDefault(cell.Id, 0f));
             }
         }
 
@@ -85,7 +85,7 @@ public class WorldMapScreen : ScreenBase
             var cell = cells[cellId];
             float sourceVisibility = _cellVisibility[cellId];
 
-            foreach (var neighborId in cell.c)
+            foreach (var neighborId in cell.Neighbors)
             {
                 if (neighborId < 0 || neighborId >= cells.Count) continue;
 
@@ -185,9 +185,9 @@ public class WorldMapScreen : ScreenBase
     {
         if (_polygonRenderer == null) return;
 
-        var map = SaveGameService.CurrentMap;
-        var cells = map.Collections.cells;
-        var vertices = map.vertices;
+        var map = SaveGameService.CurrentWorld;
+        var cells = map.Cells;
+        var vertices = map.Vertices;
 
         if (vertices == null || vertices.Count == 0) return;
 
@@ -201,19 +201,19 @@ public class WorldMapScreen : ScreenBase
 
         foreach (var cell in cells)
         {
-            if (!_cellVisibility.TryGetValue(cell.i, out float visibility))
+            if (!_cellVisibility.TryGetValue(cell.Id, out float visibility))
                 continue;
 
             // Frustum culling using cell center
-            float cx = (float)cell.p[0];
-            float cy = (float)cell.p[1];
+            float cx = (float)cell.Center[0];
+            float cy = (float)cell.Center[1];
             if (cx < worldLeft || cx > worldRight || cy < worldTop || cy > worldBottom)
                 continue;
 
-            if (cell.v == null || cell.v.Count < 3) continue;
+            if (cell.VertexIndices == null || cell.VertexIndices.Count < 3) continue;
 
             // Get biome color dimmed by visibility
-            var baseColor = GetBiomeColor(cell.Biome);
+            var baseColor = GetBiomeColor(cell.BiomeType);
             var dimmedColor = new Color(
                 (int)(baseColor.R * visibility),
                 (int)(baseColor.G * visibility),
@@ -221,15 +221,15 @@ public class WorldMapScreen : ScreenBase
 
             // Convert vertices to screen space, skipping invalid indices
             var centerScreen = WorldToScreen(cx, cy, mapViewport);
-            var screenVertList = new List<Vector2>(cell.v.Count);
+            var screenVertList = new List<Vector2>(cell.VertexIndices.Count);
 
-            for (int i = 0; i < cell.v.Count; i++)
+            for (int i = 0; i < cell.VertexIndices.Count; i++)
             {
-                int vi = cell.v[i];
+                int vi = cell.VertexIndices[i];
                 if (vi < 0 || vi >= vertices.Count) continue;
 
                 var v = vertices[vi];
-                screenVertList.Add(WorldToScreen((float)v.p[0], (float)v.p[1], mapViewport));
+                screenVertList.Add(WorldToScreen((float)v.P[0], (float)v.P[1], mapViewport));
             }
 
             if (screenVertList.Count < 3) continue;
@@ -242,7 +242,7 @@ public class WorldMapScreen : ScreenBase
     private void DrawPlayerIndicator(SpriteBatch spriteBatch, Rectangle mapViewport)
     {
         var cell = SaveGameService.CurrentCell;
-        var screenPos = WorldToScreen((float)cell.p[0], (float)cell.p[1], mapViewport);
+        var screenPos = WorldToScreen((float)cell.Center[0], (float)cell.Center[1], mapViewport);
 
         int cx = (int)screenPos.X;
         int cy = (int)screenPos.Y;
@@ -255,10 +255,10 @@ public class WorldMapScreen : ScreenBase
 
     private void DrawCityOfLightIndicator(SpriteBatch spriteBatch, Rectangle mapViewport)
     {
-        if (_cityOfLight?.x == null || _cityOfLight.y == null)
+        if (_cityOfLight?.X == null || _cityOfLight.Y == null)
             return;
 
-        var screenPos = WorldToScreen((float)_cityOfLight.x.Value, (float)_cityOfLight.y.Value, mapViewport);
+        var screenPos = WorldToScreen((float)_cityOfLight.X.Value, (float)_cityOfLight.Y.Value, mapViewport);
 
         int cx = (int)screenPos.X;
         int cy = (int)screenPos.Y;
@@ -270,12 +270,12 @@ public class WorldMapScreen : ScreenBase
         DrawRect(spriteBatch, new Rectangle(cx - 1, cy - 1, 3, 3), Color.White);
 
         // Label
-        if (_cityOfLight.name != null)
+        if (_cityOfLight.Name != null)
         {
             var shadowColor = new Color(0, 0, 0, 180);
             var labelPos = new Vector2(cx + r + 4, cy - 8);
-            DrawText(spriteBatch, _cityOfLight.name, labelPos + new Vector2(1, 1), shadowColor);
-            DrawText(spriteBatch, _cityOfLight.name, labelPos, Color.White);
+            DrawText(spriteBatch, _cityOfLight.Name, labelPos + new Vector2(1, 1), shadowColor);
+            DrawText(spriteBatch, _cityOfLight.Name, labelPos, Color.White);
         }
     }
 
@@ -289,14 +289,14 @@ public class WorldMapScreen : ScreenBase
     private void CenterOnPlayer()
     {
         var cell = SaveGameService.CurrentCell;
-        CenterOn((float)cell.p[0], (float)cell.p[1]);
+        CenterOn((float)cell.Center[0], (float)cell.Center[1]);
     }
 
     private void CenterOnCityOfLight()
     {
-        if (_cityOfLight?.x != null && _cityOfLight.y != null)
+        if (_cityOfLight?.X != null && _cityOfLight.Y != null)
         {
-            CenterOn((float)_cityOfLight.x.Value, (float)_cityOfLight.y.Value);
+            CenterOn((float)_cityOfLight.X.Value, (float)_cityOfLight.Y.Value);
         }
     }
 

--- a/docs/WORLD_DOL_FORMAT.md
+++ b/docs/WORLD_DOL_FORMAT.md
@@ -116,6 +116,19 @@ It also deliberately **excludes per-playthrough player progress**. The canonical
 exploration/discovery state (`ExploredPercent`, `Discovered`, `LastExplored`) and player/party data
 (`Party`, `CurrentPlayerId`) live in the **save game**, not in `world.dol`.
 
+### Runtime progress and save games (Phase 2)
+
+The game loads `world.dol` directly (`MapService.LoadWorld` → `SaveGameService.CurrentWorld`) and runs
+entirely off `DolWorld` — Azgaar shapes are no longer used at runtime. To keep the canonical file
+clean while still tracking progress, `WorldCell` and `WorldLocation` carry the mutable progress fields
+(`ExploredPercent`, `Discovered`, `LastExplored`) annotated
+`[JsonIgnore(Condition = WhenWritingDefault)]`. A freshly baked world has them all at default, so they
+are **omitted from `world.dol`**; once the player makes progress they are non-default and get written.
+
+A save file is a **`SaveGame`** (`Models/World/SaveGame.cs`) — the `DolWorld` (now carrying progress)
+plus `Party` and `CurrentPlayerId` — serialized with the same `DolWorldSerializer.Options`. This is
+distinct from the shipped, progress-free `world.dol`.
+
 ## Example
 
 A trimmed `world.dol` (one cell, one burg with an authored enrichment block):


### PR DESCRIPTION
Closes #75. Phase 2 of the WorldForge epic (#72). The game now **loads a baked `world.dol`** and runs entirely off `DolWorld` — runtime world provisioning is retired and Azgaar shapes are no longer used at runtime (they're purely a WorldForge input now).

## What changed

**Game core → DolWorld.** `SaveGameService.CurrentWorld` is a `DolWorld`; all derived accessors (`CurrentCell/Burg/Province/State/Biome/Location`, `Get*`) resolve over `World` types. `MapService.LoadWorld` deserializes a baked `world.dol` via `DolWorldSerializer` and **only places the player** — no re-provisioning. `MoveService`/`EventService`/`Event`/`Scene` read `DolWorld`.

**All 6 screens + Game1** converted from Azgaar `Map`/`Cell`/`Burg`/`Location` to `DolWorld` types. Added computed helpers (`WorldCell.BiomeType/CellSize/PopDensity`, `WorldLocation.Type` rehydrated from the `LocationTypes` catalog via a new `LocationTypes.Get`).

**Progress vs. canonical separation.** `WorldCell`/`WorldLocation` carry mutable `ExploredPercent`/`Discovered`/`LastExplored` annotated `[JsonIgnore(WhenWritingDefault)]`, so a freshly baked `world.dol` omits them while save files keep them. Saves are now a `SaveGame` wrapper (`DolWorld` + party + player) — **old `Map`-based saves are intentionally dropped** (2.0.0-alpha).

**Shipping.** The canonical Ouvia world ships as `DolCon.MonoGame/Worlds/Ouvia.world.dol` (baked by WorldForge) and installs to `%APPDATA%/DolCon/Worlds` on first run; the raw Azgaar export is no longer copied to the game.

## Acceptance criteria

- ✅ Starting a new game loads `world.dol`; City of Light (Lympsin), challenge ratings, and locations are identical run-to-run (no re-roll).
- ✅ All existing tests pass; the slimmer format loads fine.
- ✅ Raw Azgaar exports are no longer required at runtime; the game depends only on `DolWorld`.

## Tests / verification

- Full solution builds (0 warnings); **279 Core tests pass**, including new save-state accessor, location-rehydration, clean-bake-omits-progress, and `SaveGame` progress round-trip tests.
- Smoke-verified the real **11 MB shipped `Ouvia.world.dol`** deserializes into a complete `DolWorld` (6095 cells, 450 burgs, City of Light = Lympsin, types rehydrate, no progress fields leaked).
- The game **launches and renders the main menu** (verified visually).

> **Note:** I could not automate the full in-game *New Game → character creation → Home* keyboard walkthrough — this MonoGame/SDL2 app doesn't register synthetic keystrokes (osascript/cliclick), and its menus are keyboard-only. A ~30-second manual click-through (`dotnet run --project DolCon.MonoGame`) closes that last gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)